### PR TITLE
Parallelize the example conversion

### DIFF
--- a/cmd/pulumi-converter-terraform/main.go
+++ b/cmd/pulumi-converter-terraform/main.go
@@ -114,7 +114,7 @@ func (*tfConverter) ConvertProgram(_ context.Context,
 		}
 
 		workers := -1 // numCPU
-		batch := 128
+		batch := 16
 
 		results, err := parTransformMapWith(examples, translateExample, workers, batch)
 

--- a/cmd/pulumi-converter-terraform/main.go
+++ b/cmd/pulumi-converter-terraform/main.go
@@ -91,13 +91,12 @@ func (*tfConverter) ConvertProgram(_ context.Context,
 		}
 
 		// For each example make up a small InMemFs for it and run the translation and save the results
-		results := make(map[string]translatedExample)
-		for name, example := range examples {
+		translateExample := func(name, example string) (translatedExample, error) {
 			src := afero.NewMemMapFs()
 			safename := strings.ReplaceAll(name, "/", "-")
 			err := afero.WriteFile(src, "/"+safename+".tf", []byte(example), 0o600)
 			if err != nil {
-				return nil, fmt.Errorf("write example %s to memory store: %w", name, err)
+				return translatedExample{}, fmt.Errorf("write example %s to memory store: %w", name, err)
 			}
 
 			dst := afero.NewMemMapFs()
@@ -105,14 +104,19 @@ func (*tfConverter) ConvertProgram(_ context.Context,
 
 			pcl, err := afero.ReadFile(dst, "/"+safename+".pp")
 			if err != nil && !os.IsNotExist(err) {
-				return nil, fmt.Errorf("read example %s from memory store: %w", name, err)
+				return translatedExample{}, fmt.Errorf("read example %s from memory store: %w", name, err)
 			}
 
-			results[name] = translatedExample{
+			return translatedExample{
 				PCL:         string(pcl),
 				Diagnostics: diags,
-			}
+			}, nil
 		}
+
+		workers := -1 // numCPU
+		batch := 128
+
+		results, err := parTransformMapWith(examples, translateExample, workers, batch)
 
 		// Now marshal the results and return them, we use the same base name as our input file but written to the
 		// target directory

--- a/cmd/pulumi-converter-terraform/main.go
+++ b/cmd/pulumi-converter-terraform/main.go
@@ -114,9 +114,8 @@ func (*tfConverter) ConvertProgram(_ context.Context,
 		}
 
 		workers := -1 // numCPU
-		batch := 16
 
-		results, err := parTransformMapWith(examples, translateExample, workers, batch)
+		results, err := parTransformMapWith(examples, translateExample, workers)
 
 		// Now marshal the results and return them, we use the same base name as our input file but written to the
 		// target directory

--- a/cmd/pulumi-converter-terraform/par.go
+++ b/cmd/pulumi-converter-terraform/par.go
@@ -1,0 +1,126 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+)
+
+// Transforms a large map in batches of up to batch elements, using workers number of goroutines. If
+// workers is -1, uses one worker per CPU.
+func parTransformMap[K comparable, T any, U any](
+	inputs map[K]T,
+	transform func(map[K]T) (map[K]U, error),
+	workers int,
+	batch int,
+) (map[K]U, error) {
+	if batch < 1 {
+		return nil, fmt.Errorf("batch cannot be less than 1")
+	}
+	n := workers
+	if workers < 1 {
+		n = runtime.NumCPU()
+		if n < 2 {
+			n = 2
+		}
+	}
+
+	keys := []K{}
+	keyIndex := map[K]int{}
+	for k := range inputs {
+		keys = append(keys, k)
+		keyIndex[k] = len(keys) - 1
+	}
+
+	translations := make([]U, len(keys))
+	errors := make([]error, n)
+
+	ch := make(chan []K)
+
+	// Start n workers to do convertViaPulumiCLI work
+	wg := sync.WaitGroup{}
+	wg.Add(n)
+
+	for i := 0; i < n; i++ {
+		go func(worker int) {
+			defer wg.Done()
+			for keyBatch := range ch {
+				ex := map[K]T{}
+				for _, k := range keyBatch {
+					ex[k] = inputs[k]
+				}
+				out, err := transform(ex)
+				if err != nil {
+					errors[worker] = err
+					return
+				}
+				for _, k := range keyBatch {
+					translations[keyIndex[k]] = out[k]
+				}
+			}
+		}(i)
+	}
+
+	// Queue up work in batches.
+	remainingKeys := keys
+	for len(remainingKeys) > 0 {
+		var keyBatch []K
+		if len(remainingKeys) <= batch {
+			keyBatch, remainingKeys = remainingKeys, nil
+		} else {
+			keyBatch, remainingKeys = remainingKeys[:batch], remainingKeys[batch:]
+		}
+		ch <- keyBatch
+	}
+	close(ch)
+
+	// Wait till workers are done.
+	wg.Wait()
+
+	for _, e := range errors {
+		// Returning the first error here, could instead consider merging them.
+		if e != nil {
+			return nil, e
+		}
+	}
+
+	translatedMap := map[K]U{}
+	for _, k := range keys {
+		translatedMap[k] = translations[keyIndex[k]]
+	}
+	return translatedMap, nil
+}
+
+func parTransformMapWith[K comparable, T any, U any](
+	inputs map[K]T,
+	transform func(K, T) (U, error),
+	workers int,
+	batch int,
+) (map[K]U, error) {
+	t := func(m map[K]T) (map[K]U, error) {
+		r := map[K]U{}
+		for k, v := range m {
+			tv, err := transform(k, v)
+			if err != nil {
+				return nil, err
+			}
+			r[k] = tv
+		}
+		return r, nil
+	}
+	return parTransformMap(inputs, t, workers, batch)
+}

--- a/cmd/pulumi-converter-terraform/par.go
+++ b/cmd/pulumi-converter-terraform/par.go
@@ -19,7 +19,7 @@ import (
 	"sync"
 )
 
-// Transforms map values in parallel over n workers. If workers is negaive use NumCPU.
+// Transforms map values in parallel over n workers. If workers is negative use NumCPU.
 func parTransformMapWith[K comparable, T any, U any](
 	inputs map[K]T,
 	transform func(K, T) (U, error),

--- a/cmd/pulumi-converter-terraform/par_test.go
+++ b/cmd/pulumi-converter-terraform/par_test.go
@@ -1,0 +1,87 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"math"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParTransformMap(t *testing.T) {
+
+	mkMap := func(n int) map[int]int {
+		m := map[int]int{}
+		for i := 0; i < n; i++ {
+			m[i] = 2 * i
+		}
+		return m
+	}
+
+	inputs := mkMap(1000)
+
+	inputsBad := mkMap(1000)
+	inputsBad[4] = -8
+
+	type testCase struct {
+		inputs  map[int]int
+		workers int
+		batch   int
+	}
+
+	increment := func(m map[int]int) (map[int]int, error) {
+		out := map[int]int{}
+		for k, v := range m {
+			if v < 0 {
+				return nil, fmt.Errorf("neg")
+			}
+			out[k] = v + 1
+		}
+		return out, nil
+	}
+
+	testCases := []testCase{
+		{inputs, -1, 3},
+		{inputs, 2, 3},
+		{inputs, 4, 3},
+		{inputsBad, -1, 3},
+		{inputsBad, 2, 3},
+		{inputsBad, 4, 3},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(fmt.Sprintf("w%d__b%d", tc.workers, tc.batch), func(t *testing.T) {
+			var ops atomic.Uint64
+
+			inc := func(m map[int]int) (map[int]int, error) {
+				assert.LessOrEqual(t, len(m), tc.batch)
+				ops.Add(1)
+				return increment(m)
+			}
+
+			actual, actualErr := parTransformMap(tc.inputs, inc, tc.workers, tc.batch)
+			expect, expectErr := increment(tc.inputs)
+			assert.Equal(t, int(math.Ceil(float64(len(tc.inputs))/float64(tc.batch))),
+				int(ops.Load()))
+			assert.Equal(t, expectErr, actualErr)
+			assert.Equal(t, expect, actual)
+		})
+	}
+}

--- a/cmd/pulumi-converter-terraform/par_test.go
+++ b/cmd/pulumi-converter-terraform/par_test.go
@@ -72,7 +72,7 @@ func TestParTransformMap(t *testing.T) {
 			actual, actualErr := parTransformMapWith(tc.inputs, inc, tc.workers)
 			expect, expectErr := apply(increment, tc.inputs)
 			assert.Equal(t, len(tc.inputs), int(ops.Load()))
-			assert.Equal(t, expectErr, actualErr)
+			assert.Equal(t, expectErr == nil, actualErr == nil)
 			assert.Equal(t, expect, actual)
 		})
 	}


### PR DESCRIPTION
Trying this out as AWS build is a little sluggish. This increases CPU utilization in the converter  by loading all the cores and speeds things up a little. This is part of the solution that speeds up AWS from 30-40 min to <7 min, highly appreciated to improve iteration speed.