### PR TITLE
Better readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to Pulumi
+
+First, thanks for contributing to Pulumi and helping make it better. We appreciate the help!
+This repository is one of many across the Pulumi ecosystem and we welcome contributions to them all.
+
+## Code of Conduct
+
+Please make sure to read and observe our [Contributor Code of Conduct](https://github.com/pulumi/pulumi/blob/master/CODE-OF-CONDUCT.md).
+
+## Communications
+
+You are welcome to join the [Pulumi Community Slack](https://slack.pulumi.com/) for questions and a community of like-minded folks.
+We discuss features and file bugs on GitHub via [Issues](https://github.com/pulumi/pulumi/issues) as well as [Discussions](https://github.com/pulumi/pulumi/discussions).
+You can read about our [public roadmap](https://github.com/orgs/pulumi/projects/44) on the [Pulumi blog](https://www.pulumi.com/blog/relaunching-pulumis-public-roadmap/).
+
+### Issues
+
+Feel free to pick up any existing issue that looks interesting to you or fix a bug you stumble across while using Pulumi. No matter the size, we welcome all improvements.
+
+### Feature Work
+
+For larger features, we'd appreciate it if you open a [new issue](https://github.com/pulumi/pulumi/issues/new) before investing a lot of time so we can discuss the feature together.
+Please also be sure to browse [current issues](https://github.com/pulumi/pulumi/issues) to make sure your issue is unique, to lighten the triage burden on our maintainers.
+Finally, please limit your pull requests to contain only one feature at a time. Separating feature work into individual pull requests helps speed up code review and reduces the barrier to merge.
+
+## Developing
+
+### Setting up your Pulumi development environment
+
+You'll want to install the following on your machine:
+
+- [Go](https://go.dev/dl/) (a [supported version](https://go.dev/doc/devel/release#policy))
+- [Golangci-lint](https://github.com/golangci/golangci-lint)
+- [gofumpt](https://github.com/mvdan/gofumpt):
+  see [installation](https://github.com/mvdan/gofumpt#installation) for editor setup instructions
+- [Pulumictl](https://github.com/pulumi/pulumictl)
+
+### Installing Pulumi dependencies on macOS
+
+You can get all required dependencies with brew and npm
+
+```bash
+brew install go@1.21 golangci/tap/golangci-lint gofumpt pulumi/tap/pulumictl
+```
+
+### Make build system
+
+We use `make` as our build system, so you'll want to install that as well, if you don't have it already.
+
+### Building
+
+`pulumi-converter-terraform` uses [Go modules](https://github.com/golang/go/wiki/Modules) to manage
+dependencies. If you want to develop `pulumi-converter-terraform` itself, you'll need to have
+[Go](https://golang.org/) installed in order to build. Once this prerequisite is installed, run the following
+to build the `pulumi-converter-terraform` binary and install it into `$GOPATH/bin`:
+
+```console
+$ make install
+```
+
+Go should automatically handle pulling the dependencies for you.
+
+If `$GOPATH/bin` is not on your path, you may want to move the `pulumi-converter-terraform` binary from `$GOPATH/bin`
+into a directory that is on your path.
+
+## Submitting a Pull Request
+
+For contributors we use the [standard fork based workflow](https://gist.github.com/Chaser324/ce0505fbed06b947d962): Fork this repository, create a topic branch, and when ready, open a pull request from your fork.
+
+Before you open a pull request, make sure all lint checks pass:
+
+```bash
+$ make lint
+```
+
+If you see formatting failures, fix them by running [gofumpt](https://github.com/mvdan/gofumpt) on your code:
+
+```bash
+$ gofumpt -w path/to/file.go
+# or
+$ gofumpt -w path/to/dir
+```
+
+## Getting Help
+
+We're sure there are rough edges and we appreciate you helping out. If you want to talk with other folks in the Pulumi community (including members of the Pulumi team) come hang out in the `#contribute` channel on the [Pulumi Community Slack](https://slack.pulumi.com/).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,119 @@
-# pulumi-converter-terraform
+# Pulumi Terraform Converter Plugin
+
+[![Build Status](https://github.com/pulumi/pulumi-converter-terraform/actions/workflows/publish-snapshot.yaml/badge.svg)](https://github.com/pulumi/pulumi-converter-terraform/actions/workflows/publish-snapshot.yaml)
+
+Convert Terraform projects to Pulumi programs written in your favourite languages.
+
+## Goals
+
+The goal of `pulumi-converter-terraform` is to help users efficiently convert Terraform-managed infrastructure
+into Pulumi stacks. It translates HCL configuration into Pulumi programs. And Terraform state files into
+Pulumi import files.
+
+## Building and Installation
+
+To use `pulumi-converter-terraform` you can build the tool from source or you can use one of the [binary
+releases](https://github.com/pulumi/tf2pulumi/releases) hosted on GitHub.
+
+### Install
+`pulumi-converter-terraform` can be installed using Pulumi's plugin system:
+```console
+pulumi plugin install converter terraform
+```
+
+### Building
+
+`pulumi-converter-terraform` uses [Go modules](https://github.com/golang/go/wiki/Modules) to manage dependencies. If you want to develop `pulumi-converter-terraform` itself, you'll need to have [Go](https://golang.org/) installed in order to build.
+Once this prerequisite is installed, run the following to build the `pulumi-converter-terraform` binary and install it into `$GOPATH/bin`:
+
+```console
+$ make install
+```
+
+Go should automatically handle pulling the dependencies for you.
+
+If `$GOPATH/bin` is not on your path, you may want to move the `pulumi-converter-terraform` binary from `$GOPATH/bin`
+into a directory that is on your path.
+
+## Usage
+
+In order to use `pulumi-converter-terraform` to convert a Terraform project to Pulumi and then deploy it,
+you'll first need to install the [Pulumi CLI](https://pulumi.io/quickstart/install.html). Once the
+Pulumi CLI has been installed, navigate to the same directory as the Terraform project you'd like to
+import and create a new Pulumi stack in your favourite language:
+
+```console
+// For a Go project
+$ pulumi new go -f
+
+// For a TypeScript project
+$ pulumi new typescript -f
+
+// For a Python project
+$ pulumi new python -f
+
+// For a C# project
+$ pulumi new csharp -f
+
+// For a Java project
+$ pulumi new java -f
+
+// For a YAML project
+$ pulumi new yaml -f
+```
+
+Then run `pulumi convert` which will write a file in the directory that
+contains the Pulumi project you just created:
+
+```console
+// For a Go project
+$ pulumi convert --from terraform --language go
+
+// For a TypeScript project
+$ pulumi convert --from terraform --language typescript
+
+// For a Python project
+$ pulumi convert --from terraform --language python
+
+// For a C# project
+$ pulumi convert --from terraform --language csharp
+
+// For a Java project
+$ pulumi convert --from terraform --language java
+
+// For a YAML project
+$ pulumi convert --from terraform --language yaml
+```
+
+If `pulumi-converter-terraform` complains about missing Terraform resource plugins, install those plugins as
+per the instructions in the error message and re-run the command above.
+
+This will generate a Pulumi program that when run with `pulumi update` will deploy the infrastructure
+originally described by the Terraform project. Note that if your infrastructure references files or
+directories with paths relative to the location of the Terraform project, you will most likely need to update
+these paths such that they are relative to the generated file.
+
+## Adopting Resource From TFState
+
+If you would like to adopt resources from an existing `.tfstate` file under management of a Pulumi stack, you
+can use `pulumi import`. Again you will need to first install the [Pulumi
+CLI](https://pulumi.io/quickstart/install.html). Once the Pulumi CLI has been installed, navigate to the same
+directory of your Pulumi project you'd like to import to, probably the directory you created via `pulumi
+convert` above.
+
+Then run `pulumi import` which will translate the Terraform state file, and import those resources into Pulumi:
+
+```console
+$ pulumi import --from terraform ./terraform.tfstate
+```
+Once imported, the existing resources in your cloud provider can now be managed by Pulumi going forward. See
+the [Adopting Existing Cloud Resources into
+Pulumi](https://www.pulumi.com/blog/adopting-existing-cloud-resources-into-pulumi/) blog post for more details
+on importing existing resources.
+
+## Limitations
+
+While the majority of Terraform constructs are already supported, there are some gaps.
+- Various built-in interpolation functions. Calls to unimplemented functions will throw at
+  runtime.
+- `self` and `terraform` variable references.

--- a/README.md
+++ b/README.md
@@ -21,20 +21,6 @@ releases](https://github.com/pulumi/tf2pulumi/releases) hosted on GitHub.
 pulumi plugin install converter terraform
 ```
 
-### Building
-
-`pulumi-converter-terraform` uses [Go modules](https://github.com/golang/go/wiki/Modules) to manage dependencies. If you want to develop `pulumi-converter-terraform` itself, you'll need to have [Go](https://golang.org/) installed in order to build.
-Once this prerequisite is installed, run the following to build the `pulumi-converter-terraform` binary and install it into `$GOPATH/bin`:
-
-```console
-$ make install
-```
-
-Go should automatically handle pulling the dependencies for you.
-
-If `$GOPATH/bin` is not on your path, you may want to move the `pulumi-converter-terraform` binary from `$GOPATH/bin`
-into a directory that is on your path.
-
 ## Usage
 
 In order to use `pulumi-converter-terraform` to convert a Terraform project to Pulumi and then deploy it,
@@ -117,3 +103,7 @@ While the majority of Terraform constructs are already supported, there are some
 - Various built-in interpolation functions. Calls to unimplemented functions will throw at
   runtime.
 - `self` and `terraform` variable references.
+
+## Contributing
+
+Visit [CONTRIBUTING.md](./CONTRIBUTING.md) for information on building from source or contributing improvements.


### PR DESCRIPTION
A copy of the old tf2pulumi readme touched up for pulumi-converter-terraform.

Only part I haven't copied across is the example. We should do that, but I'd like to do with an example checked into this repo and run as part of our tests, which is a bit of a bigger change than just updating the readme.

Fixes #12