### PR TITLE
Test that map keys don't get renamed

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,6 +2,8 @@
 
   - Support the `replace` function.
 
+  - Don't rename map keys.
+
 ### Bug Fixes
 
  - Fix order of parameters for the `parseint` function

--- a/pkg/convert/testdata/programs/map_keys/main.tf
+++ b/pkg/convert/testdata/programs/map_keys/main.tf
@@ -1,0 +1,17 @@
+resource "complex_resource" "a_resource" {
+    a_map_of_bool = {
+        CAPS: true
+        camelCase: false
+        snake_case: false
+        PascalCase: true
+    }
+}
+
+output "some_map_output" {
+    value = {
+        CAPS: complex_resource.a_resource.result
+        camelCase: 1
+        snake_case: 2
+        PascalCase: 3
+    }
+}

--- a/pkg/convert/testdata/programs/map_keys/pcl/main.pp
+++ b/pkg/convert/testdata/programs/map_keys/pcl/main.pp
@@ -1,0 +1,18 @@
+resource "aResource" "complex:index/index:resource" {
+  __logicalName = "a_resource"
+  aMapOfBool = {
+    CAPS       = true
+    camelCase  = false
+    snake_case = false
+    PascalCase = true
+  }
+}
+
+output "someMapOutput" {
+  value = {
+    CAPS       = aResource.result
+    camelCase  = 1
+    snakeCase  = 2
+    pascalCase = 3
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-converter-terraform/issues/100.

This doesn't fix every rename, there's still cases where we should be leaving keys as is but are renaming them.