### PR TITLE
Ensure block and attribute iteration is stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+## 1.0.14
+
+### Improvements
+
+ - Sort generated properties by the position of their keys to get deterministic output.
+
 ## 1.0.13
 
 ### Improvements

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,5 @@
 ### Improvements
 
- - Sort generated properties by the position of their keys to get deterministic output.
+ - Ensure block and attribute iteration is consistent.
 
 ### Bug Fixes

--- a/pkg/convert/testdata/programs/partial_name_conflict_stability/main.tf
+++ b/pkg/convert/testdata/programs/partial_name_conflict_stability/main.tf
@@ -1,0 +1,4 @@
+resource "simple_resource" "a_thing" {
+    input_one = "Hello ${simple_resource.test.result}"
+    input_two = complex_resource.test.result
+}

--- a/pkg/convert/testdata/programs/partial_name_conflict_stability/pcl/diagnostics.json
+++ b/pkg/convert/testdata/programs/partial_name_conflict_stability/pcl/diagnostics.json
@@ -1,0 +1,4 @@
+[
+  "warning:main.pp:2,28-32:undefined variable test:",
+  "warning:main.pp:3,19-38:undefined variable testComplexResource:"
+]

--- a/pkg/convert/testdata/programs/partial_name_conflict_stability/pcl/main.pp
+++ b/pkg/convert/testdata/programs/partial_name_conflict_stability/pcl/main.pp
@@ -1,0 +1,5 @@
+resource "aThing" "simple:index:resource" {
+  __logicalName = "a_thing"
+  inputOne      = "Hello ${test.result}"
+  inputTwo      = testComplexResource.result
+}

--- a/pkg/convert/tf_scopes.go
+++ b/pkg/convert/tf_scopes.go
@@ -163,18 +163,18 @@ func (s *scopes) getOrAddOutput(name string) string {
 	return pulumiName
 }
 
-// getPulumiName takes "name" and ensures it's unique.
-// First by appending `suffix` to it, and then appending an incrementing count
-func (s *scopes) getOrAddPulumiName(name, prefix, suffix string) string {
-	root, has := s.roots[name]
+// getOrAddPulumiName takes "path" and returns the unique name for it. First by prepending `prefix` and
+// appending `suffix` to it, and then appending an incrementing count.
+func (s *scopes) getOrAddPulumiName(path, prefix, suffix string) string {
+	root, has := s.roots[path]
 	if has {
 		return root.Name
 	}
-	parts := strings.Split(name, ".")
+	parts := strings.Split(path, ".")
 	tfName := parts[len(parts)-1]
 	pulumiName := camelCaseName(tfName)
 	pulumiName = s.generateUniqueName(pulumiName, prefix, suffix)
-	s.roots[name] = PathInfo{Name: pulumiName}
+	s.roots[path] = PathInfo{Name: pulumiName}
 	return pulumiName
 }
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-converter-terraform/issues/120.

I think we can do a bit more here to ensure the names chosen for undeclared items are better. But this at least ensures they are stable across re-runs.

Ideally given two undeclared items both called "test" _both_ of them should get a suffix, currently only one does.
It would be pretty easy to make it so undeclared items _always_ got a suffix, but then I'm not sure we want that in cases we don't have name conflicts. Something to raise another issue about based on how providers feel.