### PR TITLE
Convert expressions inside `jsonencode` calls without rewriting object keys to camelCase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 
 /go.work
 /go.work.sum
+.idea

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,4 @@
 ### Improvements
 
 ### Bug Fixes
+ - Convert expressions inside `jsonencode` calls without rewriting object keys to camelCase

--- a/pkg/convert/testdata/programs/jsonencode_preserves_casing/main.tf
+++ b/pkg/convert/testdata/programs/jsonencode_preserves_casing/main.tf
@@ -1,0 +1,12 @@
+# When converted, the object inside jsonencode should maintain the casing of the keys
+output "data" {
+  value = jsonencode({
+    "foo": "bar",
+    Content: "capitalized",
+    "Quoted": "quoted",
+    nested: [
+      { "Key": "value" },
+      { ANOTHER: "one" }
+    ]
+  })
+}

--- a/pkg/convert/testdata/programs/jsonencode_preserves_casing/pcl/main.pp
+++ b/pkg/convert/testdata/programs/jsonencode_preserves_casing/pcl/main.pp
@@ -1,0 +1,13 @@
+# When converted, the object inside jsonencode should maintain the casing of the keys
+output "data" {
+  value = toJSON({
+    "foo"     = "bar"
+    "Content" = "capitalized"
+    "Quoted"  = "quoted"
+    "nested" = [{
+      "Key" = "value"
+      }, {
+      "ANOTHER" = "one"
+    }]
+  })
+}


### PR DESCRIPTION
### Description

Fixes #123 where we special case `jsonencode` to maintain the casing of the object or expressions used as input for the function.