### PR TITLE
Emit warnings for non-supported lifecycle hooks `create_before_destroy` and `replace_triggered_by`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,7 @@
 ### Improvements
 
 - Support the `depends_on` option
+- Emit warnings when encountering non-supported lifecycle hooks `create_before_destroy` and `replace_triggered_by` 
 
 ### Bug Fixes
  - Convert expressions inside `jsonencode` calls without rewriting object keys to camelCase

--- a/pkg/convert/testdata/programs/non_supported_lifecycle_hooks_emit_warnigs/main.tf
+++ b/pkg/convert/testdata/programs/non_supported_lifecycle_hooks_emit_warnigs/main.tf
@@ -1,0 +1,15 @@
+resource "simple_resource" "a_resource" {
+    input_one = "hello"
+    input_two = true
+    lifecycle {
+        create_before_destroy = true
+    }
+}
+
+resource "simple_resource" "b_resource" {
+    input_one = "world"
+    input_two = false
+    lifecycle {
+        replace_triggered_by = [simple_resource.a_resource]
+    }
+}

--- a/pkg/convert/testdata/programs/non_supported_lifecycle_hooks_emit_warnigs/pcl/diagnostics.json
+++ b/pkg/convert/testdata/programs/non_supported_lifecycle_hooks_emit_warnigs/pcl/diagnostics.json
@@ -1,0 +1,4 @@
+[
+  "warning:non_supported_lifecycle_hooks_emit_warnigs/main.tf:1,1-40:non_supported_lifecycle_hooks_emit_warnigs/main.tf:1,1-40:converting create_before_destroy lifecycle hook is not supported:",
+  "warning:non_supported_lifecycle_hooks_emit_warnigs/main.tf:9,1-40:non_supported_lifecycle_hooks_emit_warnigs/main.tf:9,1-40:converting replace_triggered_by lifecycle hook is not supported:"
+]

--- a/pkg/convert/testdata/programs/non_supported_lifecycle_hooks_emit_warnigs/pcl/main.pp
+++ b/pkg/convert/testdata/programs/non_supported_lifecycle_hooks_emit_warnigs/pcl/main.pp
@@ -1,0 +1,11 @@
+resource "aResource" "simple:index:resource" {
+  __logicalName = "a_resource"
+  inputOne      = "hello"
+  inputTwo      = true
+}
+
+resource "bResource" "simple:index:resource" {
+  __logicalName = "b_resource"
+  inputOne      = "world"
+  inputTwo      = false
+}

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -2245,6 +2245,24 @@ func convertManagedResources(state *convertState,
 		options.Body().SetAttributeRaw("dependsOn", dependsOn)
 	}
 
+	if managedResource.Managed != nil && managedResource.Managed.CreateBeforeDestroySet {
+		state.appendDiagnostic(&hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "converting create_before_destroy lifecycle hook is not supported",
+			Subject:  managedResource.DeclRange.Ptr(),
+			Context:  managedResource.DeclRange.Ptr(),
+		})
+	}
+
+	if len(managedResource.TriggersReplacement) > 0 {
+		state.appendDiagnostic(&hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "converting replace_triggered_by lifecycle hook is not supported",
+			Subject:  managedResource.DeclRange.Ptr(),
+			Context:  managedResource.DeclRange.Ptr(),
+		})
+	}
+
 	// Does this resource have a count? If so set the "range" attribute
 	if managedResource.Count != nil {
 		if options == nil {


### PR DESCRIPTION
### Description

Partially addressing https://github.com/pulumi/pulumi-aws/issues/3482 by first emitting a warning from the converter when encountering these non-supported lifecycle hooks. Then in the bridge, we will do a pass over the diagnostics, detect these and turn them into errors so that the examples no longer will show up in the registry docs