### PR TITLE
Implement tolist to reduce AWS provider warnings

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,5 @@
 ### Improvements
 
+- Support the standard `tolist` function translation by the rewrite rule `tolist(x) ==> x`
 
 ### Bug Fixes

--- a/pkg/convert/testdata/programs/builtin_functions/pcl/diagnostics.json
+++ b/pkg/convert/testdata/programs/builtin_functions/pcl/diagnostics.json
@@ -109,8 +109,6 @@
   "warning:builtin_functions/main.tf:1006,11-23:Function not yet implemented:Function tobool not yet implemented",
   "warning:builtin_functions/main.tf:1009,11-23:Function not yet implemented:Function tobool not yet implemented",
   "warning:builtin_functions/main.tf:1012,11-20:Function not yet implemented:Function tobool not yet implemented",
-  "warning:builtin_functions/main.tf:1018,11-34:Function not yet implemented:Function tolist not yet implemented",
-  "warning:builtin_functions/main.tf:1021,11-32:Function not yet implemented:Function tolist not yet implemented",
   "warning:builtin_functions/main.tf:1027,11-36:Function not yet implemented:Function tomap not yet implemented",
   "warning:builtin_functions/main.tf:1030,11-43:Function not yet implemented:Function tomap not yet implemented",
   "warning:builtin_functions/main.tf:1036,11-22:Function not yet implemented:Function tonumber not yet implemented",

--- a/pkg/convert/testdata/programs/builtin_functions/pcl/main.pp
+++ b/pkg/convert/testdata/programs/builtin_functions/pcl/main.pp
@@ -1396,10 +1396,10 @@ output "funcTobool4" {
 
 # Examples for tolist
 output "funcTolist0" {
-  value = notImplemented("tolist([\"a\",\"b\",\"c\"])")
+  value = ["a", "b", "c"]
 }
 output "funcTolist1" {
-  value = notImplemented("tolist([\"a\",\"b\",3])")
+  value = ["a", "b", 3]
 }
 
 

--- a/pkg/convert/testdata/programs/registry_module/pcl/subnets_1.0.0/outputs.pp
+++ b/pkg/convert/testdata/programs/registry_module/pcl/subnets_1.0.0/outputs.pp
@@ -3,7 +3,7 @@ output "networkCidrBlocks" {
 }
 
 output "networks" {
-  value = notImplemented("tolist(local.network_objs)")
+  value = networkObjs
 }
 
 output "baseCidrBlock" {

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -826,6 +826,12 @@ func convertFunctionCallExpr(state *convertState,
 		return listTokens
 	}
 
+	// Translate tolist(x) as x - in TF this normalizes sets to lists, but in Pulumi everything is represented as a
+	// list anyway so a no-op is warranted.
+	if call.Name == "tolist" && len(args) == 1 {
+		return args[0]
+	}
+
 	// Next see if this is a rename
 	if newName, has := tfFunctionRenames[call.Name]; has {
 		return hclwrite.TokensForFunctionCall(newName, args...)


### PR DESCRIPTION
## Implement tolist

https://developer.hashicorp.com/terraform/language/functions/tolist

To a first approximation this seems to be used to ensure that something that used to be list-typed or set-typed is certainly list-typed in TF. In the Pulumi translation the distinction is lost as sets are represented as lists. This PR suggests an identity translation rule. 

Tested on this example:

```terraform
resource "aws_apigatewayv2_deployment" "example" {
  api_id      = aws_apigatewayv2_api.example.id
  description = "Example deployment"

  triggers = {
    redeployment = sha1(join(",", tolist([
      jsonencode(aws_apigatewayv2_integration.example),
      jsonencode(aws_apigatewayv2_route.example),
    ])))
  }

  lifecycle {
    create_before_destroy = true
  }
}
```

Which now translates as:

```typescript
import * as pulumi from "@pulumi/pulumi";
import * as aws from "@pulumi/aws";
import * as std from "@pulumi/std";

const example = new aws.apigatewayv2.Deployment("example", {
    apiId: exampleAwsApigatewayv2Api.id,
    description: "Example deployment",
    triggers: {
        redeployment: std.sha1Output({
            input: std.joinOutput({
                separator: ",",
                input: [
                    JSON.stringify(exampleAwsApigatewayv2Integration),
                    JSON.stringify(exampleAwsApigatewayv2Route),
                ],
            }).apply(invoke => invoke.result),
        }).apply(invoke => invoke.result),
    },
});
```

Which is much better. Still has the dangling variable problem.

Full list of warnings from pulumi-aws mentioning tolist:

```
      4:   1 warning: failed to convert HCL for #/functions/aws:ec2/getManagedPrefixLists:getManagedPrefixLists to csharp: :9,11-65: Function not yet implemented; Function tolist not yet implemented
      5:   1 warning: failed to convert HCL for #/functions/aws:ec2/getManagedPrefixLists:getManagedPrefixLists to go: :9,11-65: Function not yet implemented; Function tolist not yet implemented
      6:   1 warning: failed to convert HCL for #/functions/aws:ec2/getManagedPrefixLists:getManagedPrefixLists to java: :9,11-65: Function not yet implemented; Function tolist not yet implemented
      7:   1 warning: failed to convert HCL for #/functions/aws:ec2/getManagedPrefixLists:getManagedPrefixLists to python: :9,11-65: Function not yet implemented; Function tolist not yet implemented
      8:   1 warning: failed to convert HCL for #/functions/aws:ec2/getManagedPrefixLists:getManagedPrefixLists to typescript: :9,11-65: Function not yet implemented; Function tolist not yet implemented
      9:   1 warning: failed to convert HCL for #/functions/aws:ec2/getManagedPrefixLists:getManagedPrefixLists to yaml: :9,11-65: Function not yet implemented; Function tolist not yet implemented
     10:   1 warning: failed to convert HCL for #/functions/aws:ec2/getNatGateways:getNatGateways to csharp: :12,11-49: Function not yet implemented; Function tolist not yet implemented
     11:   1 warning: failed to convert HCL for #/functions/aws:ec2/getNatGateways:getNatGateways to go: :12,11-49: Function not yet implemented; Function tolist not yet implemented
     12:   1 warning: failed to convert HCL for #/functions/aws:ec2/getNatGateways:getNatGateways to java: :12,11-49: Function not yet implemented; Function tolist not yet implemented
     13:   1 warning: failed to convert HCL for #/functions/aws:ec2/getNatGateways:getNatGateways to python: :12,11-49: Function not yet implemented; Function tolist not yet implemented
     14:   1 warning: failed to convert HCL for #/functions/aws:ec2/getNatGateways:getNatGateways to typescript: :12,11-49: Function not yet implemented; Function tolist not yet implemented
     15:   1 warning: failed to convert HCL for #/functions/aws:ec2/getNatGateways:getNatGateways to yaml: :12,11-49: Function not yet implemented; Function tolist not yet implemented
     16:   1 warning: failed to convert HCL for #/functions/aws:ec2/getRouteTables:getRouteTables to csharp: :12,31-68: Function not yet implemented; Function tolist not yet implemented
     17:   1 warning: failed to convert HCL for #/functions/aws:ec2/getRouteTables:getRouteTables to go: :12,31-68: Function not yet implemented; Function tolist not yet implemented
     18:   1 warning: failed to convert HCL for #/functions/aws:ec2/getRouteTables:getRouteTables to java: :12,31-68: Function not yet implemented; Function tolist not yet implemented
     19:   1 warning: failed to convert HCL for #/functions/aws:ec2/getRouteTables:getRouteTables to python: :12,31-68: Function not yet implemented; Function tolist not yet implemented
     20:   1 warning: failed to convert HCL for #/functions/aws:ec2/getRouteTables:getRouteTables to typescript: :12,31-68: Function not yet implemented; Function tolist not yet implemented
     21:   1 warning: failed to convert HCL for #/functions/aws:ec2/getRouteTables:getRouteTables to yaml: :12,31-68: Function not yet implemented; Function tolist not yet implemented
     28:   1 warning: failed to convert HCL for #/functions/aws:ec2/getVpcs:getVpcs to csharp: :5,11-40: Function not yet implemented; Function tolist not yet implemented
     29:   1 warning: failed to convert HCL for #/functions/aws:ec2/getVpcs:getVpcs to go: :5,11-40: Function not yet implemented; Function tolist not yet implemented
     30:   1 warning: failed to convert HCL for #/functions/aws:ec2/getVpcs:getVpcs to java: :5,11-40: Function not yet implemented; Function tolist not yet implemented
     31:   1 warning: failed to convert HCL for #/functions/aws:ec2/getVpcs:getVpcs to python: :5,11-40: Function not yet implemented; Function tolist not yet implemented
     32:   1 warning: failed to convert HCL for #/functions/aws:ec2/getVpcs:getVpcs to typescript: :5,11-40: Function not yet implemented; Function tolist not yet implemented
     33:   1 warning: failed to convert HCL for #/functions/aws:ec2/getVpcs:getVpcs to yaml: :5,11-40: Function not yet implemented; Function tolist not yet implemented
     52:   1 warning: failed to convert HCL for #/functions/aws:identitystore/getGroup:getGroup to csharp: :4,23-85: Function not yet implemented; Function tolist not yet implemented
     53:   1 warning: failed to convert HCL for #/functions/aws:identitystore/getGroup:getGroup to go: :4,23-85: Function not yet implemented; Function tolist not yet implemented
     54:   1 warning: failed to convert HCL for #/functions/aws:identitystore/getGroup:getGroup to java: :4,23-85: Function not yet implemented; Function tolist not yet implemented
     55:   1 warning: failed to convert HCL for #/functions/aws:identitystore/getGroup:getGroup to python: :4,23-85: Function not yet implemented; Function tolist not yet implemented
     56:   1 warning: failed to convert HCL for #/functions/aws:identitystore/getGroup:getGroup to typescript: :4,23-85: Function not yet implemented; Function tolist not yet implemented
     57:   1 warning: failed to convert HCL for #/functions/aws:identitystore/getGroup:getGroup to yaml: :4,23-85: Function not yet implemented; Function tolist not yet implemented
     58:   1 warning: failed to convert HCL for #/functions/aws:identitystore/getUser:getUser to csharp: :4,23-85: Function not yet implemented; Function tolist not yet implemented
     59:   1 warning: failed to convert HCL for #/functions/aws:identitystore/getUser:getUser to go: :4,23-85: Function not yet implemented; Function tolist not yet implemented
     60:   1 warning: failed to convert HCL for #/functions/aws:identitystore/getUser:getUser to java: :4,23-85: Function not yet implemented; Function tolist not yet implemented
     61:   1 warning: failed to convert HCL for #/functions/aws:identitystore/getUser:getUser to python: :4,23-85: Function not yet implemented; Function tolist not yet implemented
     62:   1 warning: failed to convert HCL for #/functions/aws:identitystore/getUser:getUser to typescript: :4,23-85: Function not yet implemented; Function tolist not yet implemented
     63:   1 warning: failed to convert HCL for #/functions/aws:identitystore/getUser:getUser to yaml: :4,23-85: Function not yet implemented; Function tolist not yet implemented
     90:   1 warning: failed to convert HCL for #/functions/aws:ssoadmin/getInstances:getInstances to csharp: :4,11-59: Function not yet implemented; Function tolist not yet implemented, and 1 other diagnostic(s)
     91:   1 warning: failed to convert HCL for #/functions/aws:ssoadmin/getInstances:getInstances to go: :4,11-59: Function not yet implemented; Function tolist not yet implemented, and 1 other diagnostic(s)
     92:   1 warning: failed to convert HCL for #/functions/aws:ssoadmin/getInstances:getInstances to java: :4,11-59: Function not yet implemented; Function tolist not yet implemented, and 1 other diagnostic(s)
     93:   1 warning: failed to convert HCL for #/functions/aws:ssoadmin/getInstances:getInstances to python: :4,11-59: Function not yet implemented; Function tolist not yet implemented, and 1 other diagnostic(s)
     94:   1 warning: failed to convert HCL for #/functions/aws:ssoadmin/getInstances:getInstances to typescript: :4,11-59: Function not yet implemented; Function tolist not yet implemented, and 1 other diagnostic(s)
     95:   1 warning: failed to convert HCL for #/functions/aws:ssoadmin/getInstances:getInstances to yaml: :4,11-59: Function not yet implemented; Function tolist not yet implemented, and 1 other diagnostic(s)
     96:   1 warning: failed to convert HCL for #/functions/aws:ssoadmin/getPermissionSet:getPermissionSet to csharp: :4,18-66: Function not yet implemented; Function tolist not yet implemented
     97:   1 warning: failed to convert HCL for #/functions/aws:ssoadmin/getPermissionSet:getPermissionSet to go: :4,18-66: Function not yet implemented; Function tolist not yet implemented
     98:   1 warning: failed to convert HCL for #/functions/aws:ssoadmin/getPermissionSet:getPermissionSet to java: :4,18-66: Function not yet implemented; Function tolist not yet implemented
     99:   1 warning: failed to convert HCL for #/functions/aws:ssoadmin/getPermissionSet:getPermissionSet to python: :4,18-66: Function not yet implemented; Function tolist not yet implemented
    100:   1 warning: failed to convert HCL for #/functions/aws:ssoadmin/getPermissionSet:getPermissionSet to typescript: :4,18-66: Function not yet implemented; Function tolist not yet implemented
    101:   1 warning: failed to convert HCL for #/functions/aws:ssoadmin/getPermissionSet:getPermissionSet to yaml: :4,18-66: Function not yet implemented; Function tolist not yet implemented
    102:   1 warning: failed to convert HCL for #/functions/aws:ssoadmin/getPrincipalApplicationAssignments:getPrincipalApplicationAssignments to csharp: :2,20-65: Function not yet implemented; Function tolist not yet implemented
    103:   1 warning: failed to convert HCL for #/functions/aws:ssoadmin/getPrincipalApplicationAssignments:getPrincipalApplicationAssignments to go: :2,20-65: Function not yet implemented; Function tolist not yet implemented
    104:   1 warning: failed to convert HCL for #/functions/aws:ssoadmin/getPrincipalApplicationAssignments:getPrincipalApplicationAssignments to java: :2,20-65: Function not yet implemented; Function tolist not yet implemented
    105:   1 warning: failed to convert HCL for #/functions/aws:ssoadmin/getPrincipalApplicationAssignments:getPrincipalApplicationAssignments to python: :2,20-65: Function not yet implemented; Function tolist not yet implemented
    106:   1 warning: failed to convert HCL for #/functions/aws:ssoadmin/getPrincipalApplicationAssignments:getPrincipalApplicationAssignments to typescript: :2,20-65: Function not yet implemented; Function tolist not yet implemented
    107:   1 warning: failed to convert HCL for #/functions/aws:ssoadmin/getPrincipalApplicationAssignments:getPrincipalApplicationAssignments to yaml: :2,20-65: Function not yet implemented; Function tolist not yet implemented
    130:   1 warning: failed to convert HCL for #/resources/aws:apigatewayv2/deployment:Deployment to csharp: :6,35-9,7: Function not yet implemented; Function tolist not yet implemented
    131:   1 warning: failed to convert HCL for #/resources/aws:apigatewayv2/deployment:Deployment to go: :6,35-9,7: Function not yet implemented; Function tolist not yet implemented
    132:   1 warning: failed to convert HCL for #/resources/aws:apigatewayv2/deployment:Deployment to java: :6,35-9,7: Function not yet implemented; Function tolist not yet implemented
    133:   1 warning: failed to convert HCL for #/resources/aws:apigatewayv2/deployment:Deployment to python: :6,35-9,7: Function not yet implemented; Function tolist not yet implemented
    134:   1 warning: failed to convert HCL for #/resources/aws:apigatewayv2/deployment:Deployment to typescript: :6,35-9,7: Function not yet implemented; Function tolist not yet implemented
    135:   1 warning: failed to convert HCL for #/resources/aws:apigatewayv2/deployment:Deployment to yaml: :6,35-9,7: Function not yet implemented; Function tolist not yet implemented
    176:   1 warning: failed to convert HCL for #/resources/aws:datasync/agent:Agent to csharp: :21,8-62: Function not yet implemented; Function tolist not yet implemented
    177:   1 warning: failed to convert HCL for #/resources/aws:datasync/agent:Agent to go: :21,8-62: Function not yet implemented; Function tolist not yet implemented
    178:   1 warning: failed to convert HCL for #/resources/aws:datasync/agent:Agent to java: :21,8-62: Function not yet implemented; Function tolist not yet implemented
    179:   1 warning: failed to convert HCL for #/resources/aws:datasync/agent:Agent to python: :21,8-62: Function not yet implemented; Function tolist not yet implemented
    180:   1 warning: failed to convert HCL for #/resources/aws:datasync/agent:Agent to typescript: :21,8-62: Function not yet implemented; Function tolist not yet implemented
    181:   1 warning: failed to convert HCL for #/resources/aws:datasync/agent:Agent to yaml: :21,8-62: Function not yet implemented; Function tolist not yet implemented
    208:   1 warning: failed to convert HCL for #/resources/aws:elasticache/cluster:Cluster to csharp: :4,8-54: Function not yet implemented; Function tolist not yet implemented
    209:   1 warning: failed to convert HCL for #/resources/aws:elasticache/cluster:Cluster to go: :4,8-54: Function not yet implemented; Function tolist not yet implemented
    210:   1 warning: failed to convert HCL for #/resources/aws:elasticache/cluster:Cluster to java: :4,8-54: Function not yet implemented; Function tolist not yet implemented
    211:   1 warning: failed to convert HCL for #/resources/aws:elasticache/cluster:Cluster to python: :4,8-54: Function not yet implemented; Function tolist not yet implemented
    212:   1 warning: failed to convert HCL for #/resources/aws:elasticache/cluster:Cluster to typescript: :4,8-54: Function not yet implemented; Function tolist not yet implemented
    213:   1 warning: failed to convert HCL for #/resources/aws:elasticache/cluster:Cluster to yaml: :4,8-54: Function not yet implemented; Function tolist not yet implemented
    215:   1 warning: failed to convert HCL for #/resources/aws:identitystore/group:Group to csharp: :4,23-85: Function not yet implemented; Function tolist not yet implemented
    216:   1 warning: failed to convert HCL for #/resources/aws:identitystore/group:Group to go: :4,23-85: Function not yet implemented; Function tolist not yet implemented
    217:   1 warning: failed to convert HCL for #/resources/aws:identitystore/group:Group to java: :4,23-85: Function not yet implemented; Function tolist not yet implemented
    218:   1 warning: failed to convert HCL for #/resources/aws:identitystore/group:Group to python: :4,23-85: Function not yet implemented; Function tolist not yet implemented
    219:   1 warning: failed to convert HCL for #/resources/aws:identitystore/group:Group to typescript: :4,23-85: Function not yet implemented; Function tolist not yet implemented
    220:   1 warning: failed to convert HCL for #/resources/aws:identitystore/group:Group to yaml: :4,23-85: Function not yet implemented; Function tolist not yet implemented
    221:   1 warning: failed to convert HCL for #/resources/aws:identitystore/groupMembership:GroupMembership to csharp: :4,23-85: Function not yet implemented; Function tolist not yet implemented, and 2 other diagnostic(s)
    222:   1 warning: failed to convert HCL for #/resources/aws:identitystore/groupMembership:GroupMembership to go: :4,23-85: Function not yet implemented; Function tolist not yet implemented, and 2 other diagnostic(s)
    223:   1 warning: failed to convert HCL for #/resources/aws:identitystore/groupMembership:GroupMembership to java: :4,23-85: Function not yet implemented; Function tolist not yet implemented, and 2 other diagnostic(s)
    224:   1 warning: failed to convert HCL for #/resources/aws:identitystore/groupMembership:GroupMembership to python: :4,23-85: Function not yet implemented; Function tolist not yet implemented, and 2 other diagnostic(s)
    225:   1 warning: failed to convert HCL for #/resources/aws:identitystore/groupMembership:GroupMembership to typescript: :4,23-85: Function not yet implemented; Function tolist not yet implemented, and 2 other diagnostic(s)
    226:   1 warning: failed to convert HCL for #/resources/aws:identitystore/groupMembership:GroupMembership to yaml: :4,23-85: Function not yet implemented; Function tolist not yet implemented, and 2 other diagnostic(s)
    227:   1 warning: failed to convert HCL for #/resources/aws:identitystore/user:User to csharp: :2,23-85: Function not yet implemented; Function tolist not yet implemented
    228:   1 warning: failed to convert HCL for #/resources/aws:identitystore/user:User to go: :2,23-85: Function not yet implemented; Function tolist not yet implemented
    229:   1 warning: failed to convert HCL for #/resources/aws:identitystore/user:User to java: :2,23-85: Function not yet implemented; Function tolist not yet implemented
    230:   1 warning: failed to convert HCL for #/resources/aws:identitystore/user:User to python: :2,23-85: Function not yet implemented; Function tolist not yet implemented
    231:   1 warning: failed to convert HCL for #/resources/aws:identitystore/user:User to typescript: :2,23-85: Function not yet implemented; Function tolist not yet implemented
    232:   1 warning: failed to convert HCL for #/resources/aws:identitystore/user:User to yaml: :2,23-85: Function not yet implemented; Function tolist not yet implemented
    267:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/accountAssignment:AccountAssignment to csharp: :4,18-66: Function not yet implemented; Function tolist not yet implemented, and 2 other diagnostic(s)
    268:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/accountAssignment:AccountAssignment to csharp: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 3 other diagnostic(s)
    269:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/accountAssignment:AccountAssignment to go: :4,18-66: Function not yet implemented; Function tolist not yet implemented, and 2 other diagnostic(s)
    270:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/accountAssignment:AccountAssignment to go: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 3 other diagnostic(s)
    271:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/accountAssignment:AccountAssignment to java: :4,18-66: Function not yet implemented; Function tolist not yet implemented, and 2 other diagnostic(s)
    272:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/accountAssignment:AccountAssignment to java: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 3 other diagnostic(s)
    273:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/accountAssignment:AccountAssignment to python: :4,18-66: Function not yet implemented; Function tolist not yet implemented, and 2 other diagnostic(s)
    274:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/accountAssignment:AccountAssignment to python: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 3 other diagnostic(s)
    275:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/accountAssignment:AccountAssignment to typescript: :4,18-66: Function not yet implemented; Function tolist not yet implemented, and 2 other diagnostic(s)
    276:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/accountAssignment:AccountAssignment to typescript: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 3 other diagnostic(s)
    277:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/accountAssignment:AccountAssignment to yaml: :4,18-66: Function not yet implemented; Function tolist not yet implemented, and 2 other diagnostic(s)
    278:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/accountAssignment:AccountAssignment to yaml: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 3 other diagnostic(s)
    279:   2 warning: failed to convert HCL for #/resources/aws:ssoadmin/application:Application to csharp: :6,30-78: Function not yet implemented; Function tolist not yet implemented
    280:   2 warning: failed to convert HCL for #/resources/aws:ssoadmin/application:Application to go: :6,30-78: Function not yet implemented; Function tolist not yet implemented
    281:   2 warning: failed to convert HCL for #/resources/aws:ssoadmin/application:Application to java: :6,30-78: Function not yet implemented; Function tolist not yet implemented
    282:   2 warning: failed to convert HCL for #/resources/aws:ssoadmin/application:Application to python: :6,30-78: Function not yet implemented; Function tolist not yet implemented
    283:   2 warning: failed to convert HCL for #/resources/aws:ssoadmin/application:Application to typescript: :6,30-78: Function not yet implemented; Function tolist not yet implemented
    284:   2 warning: failed to convert HCL for #/resources/aws:ssoadmin/application:Application to yaml: :6,30-78: Function not yet implemented; Function tolist not yet implemented
    285:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/applicationAccessScope:ApplicationAccessScope to csharp: :6,30-78: Function not yet implemented; Function tolist not yet implemented
    286:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/applicationAccessScope:ApplicationAccessScope to go: :6,30-78: Function not yet implemented; Function tolist not yet implemented
    287:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/applicationAccessScope:ApplicationAccessScope to java: :6,30-78: Function not yet implemented; Function tolist not yet implemented
    288:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/applicationAccessScope:ApplicationAccessScope to python: :6,30-78: Function not yet implemented; Function tolist not yet implemented
    289:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/applicationAccessScope:ApplicationAccessScope to typescript: :6,30-78: Function not yet implemented; Function tolist not yet implemented
    290:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/applicationAccessScope:ApplicationAccessScope to yaml: :6,30-78: Function not yet implemented; Function tolist not yet implemented
    291:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/customerManagedPolicyAttachment:CustomerManagedPolicyAttachment to csharp: :5,18-66: Function not yet implemented; Function tolist not yet implemented
    292:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/customerManagedPolicyAttachment:CustomerManagedPolicyAttachment to go: :5,18-66: Function not yet implemented; Function tolist not yet implemented
    293:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/customerManagedPolicyAttachment:CustomerManagedPolicyAttachment to java: :5,18-66: Function not yet implemented; Function tolist not yet implemented
    294:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/customerManagedPolicyAttachment:CustomerManagedPolicyAttachment to python: :5,18-66: Function not yet implemented; Function tolist not yet implemented
    295:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/customerManagedPolicyAttachment:CustomerManagedPolicyAttachment to typescript: :5,18-66: Function not yet implemented; Function tolist not yet implemented
    296:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/customerManagedPolicyAttachment:CustomerManagedPolicyAttachment to yaml: :5,18-66: Function not yet implemented; Function tolist not yet implemented
    297:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/instanceAccessControlAttributes:InstanceAccessControlAttributes to csharp: :4,18-66: Function not yet implemented; Function tolist not yet implemented
    298:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/instanceAccessControlAttributes:InstanceAccessControlAttributes to go: :4,18-66: Function not yet implemented; Function tolist not yet implemented
    299:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/instanceAccessControlAttributes:InstanceAccessControlAttributes to java: :4,18-66: Function not yet implemented; Function tolist not yet implemented
    300:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/instanceAccessControlAttributes:InstanceAccessControlAttributes to python: :4,18-66: Function not yet implemented; Function tolist not yet implemented
    301:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/instanceAccessControlAttributes:InstanceAccessControlAttributes to typescript: :4,18-66: Function not yet implemented; Function tolist not yet implemented
    302:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/instanceAccessControlAttributes:InstanceAccessControlAttributes to yaml: :4,18-66: Function not yet implemented; Function tolist not yet implemented
    303:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/managedPolicyAttachment:ManagedPolicyAttachment to csharp: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 1 other diagnostic(s)
    304:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/managedPolicyAttachment:ManagedPolicyAttachment to csharp: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 3 other diagnostic(s)
    305:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/managedPolicyAttachment:ManagedPolicyAttachment to go: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 1 other diagnostic(s)
    306:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/managedPolicyAttachment:ManagedPolicyAttachment to go: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 3 other diagnostic(s)
    307:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/managedPolicyAttachment:ManagedPolicyAttachment to java: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 1 other diagnostic(s)
    308:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/managedPolicyAttachment:ManagedPolicyAttachment to java: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 3 other diagnostic(s)
    309:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/managedPolicyAttachment:ManagedPolicyAttachment to python: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 1 other diagnostic(s)
    310:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/managedPolicyAttachment:ManagedPolicyAttachment to python: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 3 other diagnostic(s)
    311:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/managedPolicyAttachment:ManagedPolicyAttachment to typescript: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 1 other diagnostic(s)
    312:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/managedPolicyAttachment:ManagedPolicyAttachment to typescript: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 3 other diagnostic(s)
    313:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/managedPolicyAttachment:ManagedPolicyAttachment to yaml: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 1 other diagnostic(s)
    314:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/managedPolicyAttachment:ManagedPolicyAttachment to yaml: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 3 other diagnostic(s)
    315:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/permissionSet:PermissionSet to csharp: :6,22-70: Function not yet implemented; Function tolist not yet implemented
    316:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/permissionSet:PermissionSet to go: :6,22-70: Function not yet implemented; Function tolist not yet implemented
    317:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/permissionSet:PermissionSet to java: :6,22-70: Function not yet implemented; Function tolist not yet implemented
    318:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/permissionSet:PermissionSet to python: :6,22-70: Function not yet implemented; Function tolist not yet implemented
    319:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/permissionSet:PermissionSet to typescript: :6,22-70: Function not yet implemented; Function tolist not yet implemented
    320:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/permissionSet:PermissionSet to yaml: :6,22-70: Function not yet implemented; Function tolist not yet implemented
    321:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/permissionSetInlinePolicy:PermissionSetInlinePolicy to csharp: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 1 other diagnostic(s)
    322:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/permissionSetInlinePolicy:PermissionSetInlinePolicy to go: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 1 other diagnostic(s)
    323:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/permissionSetInlinePolicy:PermissionSetInlinePolicy to java: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 1 other diagnostic(s)
    324:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/permissionSetInlinePolicy:PermissionSetInlinePolicy to python: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 1 other diagnostic(s)
    325:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/permissionSetInlinePolicy:PermissionSetInlinePolicy to typescript: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 1 other diagnostic(s)
    326:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/permissionSetInlinePolicy:PermissionSetInlinePolicy to yaml: :5,18-66: Function not yet implemented; Function tolist not yet implemented, and 1 other diagnostic(s)
    327:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/permissionsBoundaryAttachment:PermissionsBoundaryAttachment to csharp: :5,18-66: Function not yet implemented; Function tolist not yet implemented
    328:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/permissionsBoundaryAttachment:PermissionsBoundaryAttachment to go: :5,18-66: Function not yet implemented; Function tolist not yet implemented
    329:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/permissionsBoundaryAttachment:PermissionsBoundaryAttachment to java: :5,18-66: Function not yet implemented; Function tolist not yet implemented
    330:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/permissionsBoundaryAttachment:PermissionsBoundaryAttachment to python: :5,18-66: Function not yet implemented; Function tolist not yet implemented
    331:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/permissionsBoundaryAttachment:PermissionsBoundaryAttachment to typescript: :5,18-66: Function not yet implemented; Function tolist not yet implemented
    332:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/permissionsBoundaryAttachment:PermissionsBoundaryAttachment to yaml: :5,18-66: Function not yet implemented; Function tolist not yet implemented
    333:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/trustedTokenIssuer:TrustedTokenIssuer to csharp: :5,31-79: Function not yet implemented; Function tolist not yet implemented
    334:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/trustedTokenIssuer:TrustedTokenIssuer to go: :5,31-79: Function not yet implemented; Function tolist not yet implemented
    335:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/trustedTokenIssuer:TrustedTokenIssuer to java: :5,31-79: Function not yet implemented; Function tolist not yet implemented
    336:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/trustedTokenIssuer:TrustedTokenIssuer to python: :5,31-79: Function not yet implemented; Function tolist not yet implemented
    337:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/trustedTokenIssuer:TrustedTokenIssuer to typescript: :5,31-79: Function not yet implemented; Function tolist not yet implemented
    338:   1 warning: failed to convert HCL for #/resources/aws:ssoadmin/trustedTokenIssuer:TrustedTokenIssuer to yaml: :5,31-79: Function not yet implemented; Function tolist not yet implemented
```