### PR TITLE
Cache the mapper

### DIFF
--- a/cmd/pulumi-converter-terraform/caching_mapper.go
+++ b/cmd/pulumi-converter-terraform/caching_mapper.go
@@ -1,0 +1,53 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
+)
+
+func newCachingMapper(m convert.Mapper) convert.Mapper {
+	return &cachingMapper{
+		inner: m,
+		cache: make(map[string]map[string][]byte),
+	}
+}
+
+type cachingMapper struct {
+	inner convert.Mapper
+	mu    sync.Mutex
+	cache map[string]map[string][]byte
+}
+
+func (cm *cachingMapper) GetMapping(ctx context.Context, provider string, pulumiProvider string) ([]byte, error) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	_, ok := cm.cache[provider]
+	if !ok {
+		cm.cache[provider] = make(map[string][]byte)
+	}
+	cached, cacheHit := cm.cache[provider][pulumiProvider]
+	if cacheHit {
+		return cached, nil
+	}
+	mapping, err := cm.inner.GetMapping(ctx, provider, pulumiProvider)
+	if err != nil {
+		return nil, err
+	}
+	cm.cache[provider][pulumiProvider] = mapping
+	return mapping, nil
+}

--- a/cmd/pulumi-converter-terraform/caching_mapper_test.go
+++ b/cmd/pulumi-converter-terraform/caching_mapper_test.go
@@ -1,0 +1,65 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCachingMapper(t *testing.T) {
+	calls := 0
+	m := &testMapperWithFunc{
+		getMapping: func(ctx context.Context, provider string, pulumiProvider string) ([]byte, error) {
+			calls += 1
+			if provider == "myprov" {
+				return []byte("myprov-mappings"), nil
+			}
+			return nil, fmt.Errorf("unkonwn provider")
+		},
+	}
+
+	cm := newCachingMapper(m)
+
+	t.Run("error case", func(t *testing.T) {
+		_, err := cm.GetMapping(context.Background(), "unknown", "unknown")
+		require.Error(t, err)
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("cache miss", func(t *testing.T) {
+		mappings, err := cm.GetMapping(context.Background(), "myprov", "myprov")
+		require.NoError(t, err)
+		require.Equal(t, "myprov-mappings", string(mappings))
+		require.Equal(t, 2, calls)
+	})
+
+	t.Run("cache hit", func(t *testing.T) {
+		mappings, err := cm.GetMapping(context.Background(), "myprov", "myprov")
+		require.NoError(t, err)
+		require.Equal(t, "myprov-mappings", string(mappings))
+		require.Equal(t, 2, calls)
+	})
+}
+
+type testMapperWithFunc struct {
+	getMapping func(context.Context, string, string) ([]byte, error)
+}
+
+func (m *testMapperWithFunc) GetMapping(ctx context.Context, provider string, pulumiProvider string) ([]byte, error) {
+	return m.getMapping(ctx, provider, pulumiProvider)
+}

--- a/cmd/pulumi-converter-terraform/main.go
+++ b/cmd/pulumi-converter-terraform/main.go
@@ -77,7 +77,9 @@ func (*tfConverter) ConvertProgram(_ context.Context,
 		return nil, fmt.Errorf("create mapper: %w", err)
 	}
 
-	mapper = newCachingMapper(mapper)
+	if *convertExamples != "" {
+		mapper = newCachingMapper(mapper)
+	}
 
 	providerInfoSource := il.NewMapperProviderInfoSource(mapper)
 

--- a/cmd/pulumi-converter-terraform/main.go
+++ b/cmd/pulumi-converter-terraform/main.go
@@ -76,6 +76,9 @@ func (*tfConverter) ConvertProgram(_ context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("create mapper: %w", err)
 	}
+
+	mapper = newCachingMapper(mapper)
+
 	providerInfoSource := il.NewMapperProviderInfoSource(mapper)
 
 	if *convertExamples != "" {


### PR DESCRIPTION
Observing a lot of traffic on the local network between pulumi CLI and the converter plugin during AWS builds. Wanted to try this caching to see if this is about re-fetching the mappings repeatedly. 