### PR TITLE
Prepare for 1.0.17 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+## 1.0.17
+
+### Improvements
+
+- Support the standard `tolist` function translation by the rewrite rule `tolist(x) ==> x`
+- Don't attempt to rename object keys if the object contains any non-identifiers
+
 ## 1.0.16
 
 ### Improvements

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,4 @@
 ### Improvements
 
-- Support the standard `tolist` function translation by the rewrite rule `tolist(x) ==> x`
-- Don't attempt to rename object keys if the object contains any non-identifiers
 
 ### Bug Fixes


### PR DESCRIPTION
### Improvements

- Support the standard `tolist` function translation by the rewrite rule `tolist(x) ==> x`
- Don't attempt to rename object keys if the object contains any non-identifiers