### PR TITLE
Add custom translation of `appautoscaling` ids

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,5 @@
 ### Improvements
 
+- Support custom translation of appautoscaling ids
 
 ### Bug Fixes

--- a/pkg/convert/tf_state.go
+++ b/pkg/convert/tf_state.go
@@ -140,6 +140,40 @@ func TranslateState(info il.ProviderInfoSource, path string) (*plugin.ConvertSta
 						}
 
 						id = fmt.Sprintf("%s/%s", role, policy)
+					case "aws_appautoscaling_policy":
+						serviceNamespace, err := getString(resource.Addr.Resource, obj, "service_namespace")
+						if err != nil {
+							return nil, err
+						}
+						resourceId, err := getString(resource.Addr.Resource, obj, "resource_id")
+						if err != nil {
+							return nil, err
+						}
+						scalableDimension, err := getString(resource.Addr.Resource, obj, "scalable_dimension")
+						if err != nil {
+							return nil, err
+						}
+						name, err := getString(resource.Addr.Resource, obj, "name")
+						if err != nil {
+							return nil, err
+						}
+
+						id = fmt.Sprintf("%s/%s/%s/%s", serviceNamespace, resourceId, scalableDimension, name)
+					case "aws_appautoscaling_target":
+						serviceNamespace, err := getString(resource.Addr.Resource, obj, "service_namespace")
+						if err != nil {
+							return nil, err
+						}
+						resourceId, err := getString(resource.Addr.Resource, obj, "resource_id")
+						if err != nil {
+							return nil, err
+						}
+						scalableDimension, err := getString(resource.Addr.Resource, obj, "scalable_dimension")
+						if err != nil {
+							return nil, err
+						}
+
+						id = fmt.Sprintf("%s/%s/%s", serviceNamespace, resourceId, scalableDimension)
 					default:
 						// We only care about the id value
 						id, err = getString(resource.Addr.Resource, obj, "id")


### PR DESCRIPTION
These two resources have special import ids and were missing. Sources:
- `aws_appautoscaling_policy`: https://www.pulumi.com/registry/packages/aws/api-docs/appautoscaling/policy/#import
- `aws_appautoscaling_target`: https://www.pulumi.com/registry/packages/aws/api-docs/appautoscaling/target/#import
