### PR TITLE
name dispatched acceptance tests consistently

### DIFF
--- a/.github/workflows/pr-tests-command.yaml
+++ b/.github/workflows/pr-tests-command.yaml
@@ -1,4 +1,4 @@
-name: Acceptance Tests (Command)
+name: dispatched-acceptance-test
 
 on:
   repository_dispatch:


### PR DESCRIPTION
So that we don't open P1s if these fail.  See also https://github.com/pulumi/home/pull/3480.

Fixes https://github.com/pulumi/pulumi-converter-terraform/issues/153.