### PR TITLE
more dispatched acceptance test fixes

### DIFF
--- a/.github/workflows/pr-tests-command.yaml
+++ b/.github/workflows/pr-tests-command.yaml
@@ -23,8 +23,21 @@ jobs:
             Please view the results of the PR Build + Acceptance Tests Run [Here][1]
 
             [1]: ${{ steps.vars.outputs.run-url }}
+  lint:
+    uses: pulumi/pulumi-converter-terraform/.github/workflows/stage-lint.yml@main
+    with:
+      commit-ref: refs/pull/${{ github.event.client_payload.pull_request.number }}/merge
   test:
-    uses: pulumi/pulumi-yaml/.github/workflows/stage-test.yml@main
+    uses: pulumi/pulumi-converter-terraform/.github/workflows/stage-test.yml@main
     with:
       live-test: true
       commit-ref: refs/pull/${{ github.event.client_payload.pull_request.number }}/merge
+    secrets:
+      PULUMI_BOT_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_CI_ROLE_ARN: ${{ secrets.AWS_CI_ROLE_ARN }}
+      ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}


### PR DESCRIPTION
This is still not pulumi-yaml.  Also we should run the lint steps here, and we pass the secrets in explicitly.  The last one may or may not be required, but I've seen it done in other CI jobs, so we might as well.