### PR TITLE
update jobs for goreleaser 2.0

### DIFF
--- a/.github/workflows/publish-prerelease.yaml
+++ b/.github/workflows/publish-prerelease.yaml
@@ -19,4 +19,4 @@ jobs:
     needs: [test, lint]
     uses: ./.github/workflows/stage-publish.yml
     with:
-      goreleaser-args: -p 10 -f .goreleaser.prerelease.yml --clean --skip-validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md
+      goreleaser-args: -p 10 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -20,4 +20,4 @@ jobs:
     needs: [test, lint]
     uses: ./.github/workflows/stage-publish.yml
     with:
-      goreleaser-args: -p 10 -f .goreleaser.yml --clean --skip-validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md
+      goreleaser-args: -p 10 -f .goreleaser.yml --clean --skip=validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -22,4 +22,4 @@ jobs:
     needs: [test, lint]
     uses: ./.github/workflows/stage-publish.yml
     with:
-      goreleaser-args: -p 10 -f .goreleaser.prerelease.yml --snapshot --clean --skip-validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md
+      goreleaser-args: -p 10 -f .goreleaser.prerelease.yml --snapshot --clean --skip=validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -1,7 +1,6 @@
 dist: goreleaser
 project_name: pulumi-converter-terraform
-changelog:
-  skip: true
+version: 2
 release:
   disable: true
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 dist: goreleaser
 project_name: pulumi-converter-terraform
+version: 2
 snapshot:
   name_template: "{{ .Version }}-SNAPSHOT"
 checksum:


### PR DESCRIPTION
Goreleaser 2.0 gets installed automatically by the action. Rather than rolling back, fix it forward.  In particular this skip-validate flag was replaced by skip=validate, and the config files need to be version 2.

This is similar to what we did in
https://github.com/pulumi/pulumi-yaml/pull/585 and https://github.com/pulumi/pulumi-yaml/pull/584 for yaml.

Fixes https://github.com/pulumi/pulumi-converter-terraform/issues/154