### PR TITLE
Update `upload-artifact` action

### DIFF
--- a/.github/workflows/stage-test.yml
+++ b/.github/workflows/stage-test.yml
@@ -80,7 +80,7 @@ jobs:
 
       # Upload the original go test log as an artifact for later review
       - name: Upload test log
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-log


### PR DESCRIPTION
v3 of `actions/upload-artifact` will be deprecated on November 30, 2024. This commit bumps the version.