### PR TITLE
Add YAML field to translatedExample

### DIFF
--- a/cmd/pulumi-converter-terraform/main.go
+++ b/cmd/pulumi-converter-terraform/main.go
@@ -59,7 +59,7 @@ func (*tfConverter) ConvertState(_ context.Context,
 
 type translatedExample struct {
 	PCL         string          `json:"pcl"`
-	YAML        string          `json:"yaml"`
+	PulumiYAML  string          `json:"pulumiYaml"`
 	Diagnostics hcl.Diagnostics `json:"diagnostics"`
 }
 
@@ -115,7 +115,7 @@ func (*tfConverter) ConvertProgram(_ context.Context,
 
 			return translatedExample{
 				PCL:         string(pcl),
-				YAML:        string(yml),
+				PulumiYAML:  string(yml),
 				Diagnostics: diags,
 			}, nil
 		}


### PR DESCRIPTION
Providers team would like to make use of the converted Pulumi.yaml files for provider config during bulk conversion. This adds a "yaml" field to the bulk conversion result for that.

Fixes https://github.com/pulumi/pulumi-converter-terraform/issues/176.