### PR TITLE
Maintain logical name of keyword overlap resources.

### DIFF
--- a/pkg/convert/testdata/programs/name_overlap/pcl/diagnostics.json
+++ b/pkg/convert/testdata/programs/name_overlap/pcl/diagnostics.json
@@ -1,3 +1,3 @@
 [
-  "warning:name_overlap/main.tf:1,1-33:resource renamed to prevent keyword overlap:Renaming resource for to of type simple_resource to for_resource_pcl to prevent overlap"
+  "warning:name_overlap/main.tf:1,1-33:resource renamed to prevent keyword overlap:Renaming resource for of type simple_resource to for_resource_ to prevent overlap"
 ]

--- a/pkg/convert/testdata/programs/name_overlap/pcl/main.pp
+++ b/pkg/convert/testdata/programs/name_overlap/pcl/main.pp
@@ -1,13 +1,13 @@
-resource "forResourcePcl" "simple:index:resource" {
-  __logicalName = "for_resource_pcl"
+resource "forResource_" "simple:index:resource" {
+  __logicalName = "for"
   inputOne      = "hello"
   inputTwo      = true
 }
 
 resource "dependsOnFor" "simple:index:resource" {
   options {
-    dependsOn = [forResourcePcl]
+    dependsOn = [forResource_]
   }
-  inputOne = forResourcePcl.result
+  inputOne = forResource_.result
   inputTwo = false
 }


### PR DESCRIPTION
Followup to #207 that keeps resource logical names the same to maintain
state.

This also fixes a merged failing test (woops) that didn't run PULUMI_ACCEPT