### PR TITLE
Fix keyword overlap in terraform names (specifically for) (#207)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,7 @@
 ### Improvements
 
 - Added references to issues for missing functions in output.
+- Added code generation rename workarounds for pcl keywords.
 
 ### Bug Fixes
 

--- a/pkg/convert/testdata/programs/name_overlap/main.tf
+++ b/pkg/convert/testdata/programs/name_overlap/main.tf
@@ -1,0 +1,11 @@
+resource "simple_resource" "for" {
+    input_one = "hello"
+    input_two = true
+}
+
+resource "simple_resource" "dependsOnFor" {
+    depends_on = [simple_resource.for]
+
+    input_one = simple_resource.for.result
+    input_two = false
+}

--- a/pkg/convert/testdata/programs/name_overlap/pcl/diagnostics.json
+++ b/pkg/convert/testdata/programs/name_overlap/pcl/diagnostics.json
@@ -1,0 +1,3 @@
+[
+  "warning:name_overlap/main.tf:1,1-33:resource renamed to prevent keyword overlap:Renaming resource for to of type simple_resource to for_resource_pcl to prevent overlap"
+]

--- a/pkg/convert/testdata/programs/name_overlap/pcl/main.pp
+++ b/pkg/convert/testdata/programs/name_overlap/pcl/main.pp
@@ -1,0 +1,13 @@
+resource "forResourcePcl" "simple:index:resource" {
+  __logicalName = "for_resource_pcl"
+  inputOne      = "hello"
+  inputTwo      = true
+}
+
+resource "dependsOnFor" "simple:index:resource" {
+  options {
+    dependsOn = [forResourcePcl]
+  }
+  inputOne = forResourcePcl.result
+  inputTwo = false
+}

--- a/tests/example_test.go
+++ b/tests/example_test.go
@@ -351,9 +351,10 @@ func TestExample(t *testing.T) {
 		},
 		{
 			example: "https://github.com/aztfmod/terraform-azurerm-caf",
-			// TODO[pulumi/pulumi-converter-terraform#201]: Name overlap with keyword "for"
-			// TODO[pulumi/pulumi-terraform-bridge#1303]: panic: fatal: An assertion has failed:
-			// empty path part passed into getInfo: .recurrence.hours
+			// TODO[pulumi/pulumi-converter-terraform#186]: Should use terraform bridge, error details in pulumi/pulumi-terraform-bridge#205
+			// TODO[pulumi/pulumi-converter-terraform#206]: missing attributes vcores and clientConfig
+			// TODO[pulumi/pulumi-terraform-bridge#1303]: panic: fatal: An assertion has failed: empty path part passed into getInfo: .recurrence.hours
+			// TODO[pulumi/pulumi-converter-terraform#112]:  empty path part passed into getInfo: .recurrence.hours (same as above)
 			skip: allLanguages,
 		},
 		{


### PR DESCRIPTION
Right now it detects types and names and appends the kind and "pcl" to
help distinguish the generated types and minimize chance for overlap.

It also saves these renames to the convert state and uses them to rename
references.  Type renames are saved but not currently used.

#201

---------

Co-authored-by: Thomas Gummerer <t.gummerer@gmail.com>