### PR TITLE
Handle snake case in string literal map keys curing conversion.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,6 @@
 ### Improvements
 
+- Handle object key string literal case that is parsed as a template
 - Add references to issues for missing functions in output
 - Add code generation rename workarounds for pcl keywords
 

--- a/pkg/convert/testdata/programs/expressions/pcl/main.pp
+++ b/pkg/convert/testdata/programs/expressions/pcl/main.pp
@@ -66,9 +66,9 @@ output "complexObjectOut" {
   value = {
     aTuple = ["a", "b", "c"]
     anObject = {
-      literalKey                = 1
-      anotherLiteralKey         = 2
-      "yet_another_literal_key" = aValue
+      literalKey             = 1
+      anotherLiteralKey      = 2
+      "yetAnotherLiteralKey" = aValue
 
       // This only translates correctly in the new converter.
       (aKey) = 4

--- a/pkg/convert/testdata/programs/object_keys_renamed/main.tf
+++ b/pkg/convert/testdata/programs/object_keys_renamed/main.tf
@@ -1,0 +1,5 @@
+locals {
+  obj = {
+    "snake_case_key_becomes_camel" = "abc123",
+  }
+}

--- a/pkg/convert/testdata/programs/object_keys_renamed/pcl/main.pp
+++ b/pkg/convert/testdata/programs/object_keys_renamed/pcl/main.pp
@@ -1,0 +1,3 @@
+obj = {
+  "snakeCaseKeyBecomesCamel" = "abc123"
+}


### PR DESCRIPTION
Fixes: #181
