### PR TITLE
Handles missing expression type TemplateJoinExpr in convertExpression.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,6 @@
 ### Improvements
 
+- Add template join expression to convert expression 
 - Add references to issues for missing functions in output
 - Add code generation rename workarounds for pcl keywords
 

--- a/pkg/convert/testdata/programs/template_join_expr/main.tf
+++ b/pkg/convert/testdata/programs/template_join_expr/main.tf
@@ -1,0 +1,5 @@
+locals {
+  a_list = ["a", "b", "c"]
+  join_template_expr = "%{for v in local.a_list~}${v}%{endfor~}"
+  if_template_expr = "%{if true~}true%{else~}false%{endif~}"
+}

--- a/pkg/convert/testdata/programs/template_join_expr/pcl/main.pp
+++ b/pkg/convert/testdata/programs/template_join_expr/pcl/main.pp
@@ -1,0 +1,3 @@
+aList            = ["a", "b", "c"]
+joinTemplateExpr = "%{for v in aList~}${v}%{endfor~}"
+ifTemplateExpr   = "${true ? "true" : "false"}"

--- a/tests/example_test.go
+++ b/tests/example_test.go
@@ -122,6 +122,11 @@ func TestExample(t *testing.T) {
 		skip    stringSet
 	}{
 		{
+			example: "https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner",
+			// TODO[pulumi/pulumi-converter-terraform#212]: Hetzner cloud has various conversion issues.
+			skip: allLanguages,
+		},
+		{
 			example: "https://github.com/terraform-aws-modules/terraform-aws-security-group/examples/complete",
 			// TODO[pulumi/pulumi-converter-terraform#21]: Crashes in CI (uses too many resources?)
 			skip: allLanguages,


### PR DESCRIPTION
Without handling this we panic, so instead lets not do that and handle
this by unwrapping the inner ForExpr.

Related #212 
