### PR TITLE
Handle heredoc string delimiters

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,6 @@
 ### Improvements
 
+- Add EOT (heredoc) style string delimiter handling.
 - Add template join expression to convert expression 
 - Add references to issues for missing functions in output
 - Add code generation rename workarounds for pcl keywords

--- a/pkg/convert/testdata/programs/expressions/main.tf
+++ b/pkg/convert/testdata/programs/expressions/main.tf
@@ -99,6 +99,13 @@ So we can output the key again ${local.a_key}
 END
 }
 
+output "heredoc_with_hyphen" {
+    value = <<-END
+This is also a template.
+So we can output the key again ${local.a_key}
+END
+}
+
 output "for_tuple" {
     value = [for key, value in ["a", "b"] : "${key}:${value}:${local.a_value}" if key != 0]
 }

--- a/pkg/convert/testdata/programs/expressions/pcl/main.pp
+++ b/pkg/convert/testdata/programs/expressions/pcl/main.pp
@@ -88,7 +88,17 @@ output "quotedTemplate" {
 }
 
 output "heredoc" {
-  value = "This is also a template.\nSo we can output the key again ${aKey}\n"
+  value = <<END
+This is also a template.
+So we can output the key again ${aKey}
+END
+}
+
+output "heredocWithHyphen" {
+  value = <<-END
+This is also a template.
+So we can output the key again ${aKey}
+END
 }
 
 output "forTuple" {

--- a/pkg/convert/testdata/programs/heredoc_template_expr/main.tf
+++ b/pkg/convert/testdata/programs/heredoc_template_expr/main.tf
@@ -1,0 +1,8 @@
+locals {
+  a_list = ["a", "b", "c"]
+  join_template_expr = <<EOT
+%{for v in local.a_list~}
+${v}
+%{endfor~}
+EOT
+}

--- a/pkg/convert/testdata/programs/heredoc_template_expr/pcl/main.pp
+++ b/pkg/convert/testdata/programs/heredoc_template_expr/pcl/main.pp
@@ -1,0 +1,4 @@
+aList            = ["a", "b", "c"]
+joinTemplateExpr = <<EOT
+%{for v in aList~}${v}\n%{endfor~}
+EOT


### PR DESCRIPTION
Maintain HEREDOC (<<EOT style) strings when converting.

Previously our template and string literals only handled strings
delimited by quotes, this will inspect the source and maintain the same
string delim to handle non escaped and multiline strings.

Fixes #219 