### PR TITLE
Fix blocks of maps of resources

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,7 +2,7 @@
 
 - Add generation of pcl "package" blocks
 - Add EOT (heredoc) style string delimiter handling.
-- Add template join expression to convert expression 
+- Add template join expression to convert expression
 - Add references to issues for missing functions in output
 - Add code generation rename workarounds for pcl keywords
 
@@ -11,3 +11,5 @@
 - Fix errors being encountered but not reported to the user
 
 - Fix using a module multiple times via different constraints
+
+- Fix conversion of object blocks

--- a/pkg/convert/testdata/mappings/blocks.json
+++ b/pkg/convert/testdata/mappings/blocks.json
@@ -15,6 +15,18 @@
                         }
                     }
                 },
+                "a_map_of_resources": {
+                    "type": 6,
+                    "optional": true,
+                    "element": {
+                        "resource": {
+                            "inner_string": {
+                                "type": 4,
+                                "optional": true
+                            }
+                        }
+                    }
+                },
                 "result": {
                     "type": 4,
                     "computed": true
@@ -25,6 +37,18 @@
             "blocks_resource": {
                 "a_list_of_resources": {
                     "type": 5,
+                    "optional": true,
+                    "element": {
+                        "resource": {
+                            "inner_string": {
+                                "type": 4,
+                                "optional": true
+                            }
+                        }
+                    }
+                },
+                "a_map_of_resources": {
+                    "type": 6,
                     "optional": true,
                     "element": {
                         "resource": {

--- a/pkg/convert/testdata/programs/maps_as_blocks/main.tf
+++ b/pkg/convert/testdata/programs/maps_as_blocks/main.tf
@@ -1,0 +1,11 @@
+data "blocks_data_source" "a_data_source" {
+    a_map_of_resources {
+        inner_string = "hi"
+    }
+}
+
+resource "blocks_resource" "a_resource" {
+    a_map_of_resources {
+        inner_string = "hi"
+    }
+}

--- a/pkg/convert/testdata/programs/maps_as_blocks/pcl/main.pp
+++ b/pkg/convert/testdata/programs/maps_as_blocks/pcl/main.pp
@@ -1,0 +1,12 @@
+aDataSource = invoke("blocks:index/index:dataSource", {
+  aMapOfResources = {
+    innerString = "hi"
+  }
+})
+
+resource "aResource" "blocks:index/index:resource" {
+  __logicalName = "a_resource"
+  aMapOfResources = {
+    innerString = "hi"
+  }
+}

--- a/pkg/convert/testdata/schemas/blocks.json
+++ b/pkg/convert/testdata/schemas/blocks.json
@@ -26,7 +26,23 @@
       },
       "type": "object"
     },
+    "blocks:index/dataSourceAMapOfResources:dataSourceAMapOfResources": {
+      "properties": {
+        "innerString": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "blocks:index/resourceAListOfResource:resourceAListOfResource": {
+      "properties": {
+        "innerString": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "blocks:index/resourceAMapOfResources:resourceAMapOfResources": {
       "properties": {
         "innerString": {
           "type": "string"
@@ -47,6 +63,9 @@
             "$ref": "#/types/blocks:index/resourceAListOfResource:resourceAListOfResource"
           }
         },
+        "aMapOfResources": {
+          "$ref": "#/types/blocks:index/resourceAMapOfResources:resourceAMapOfResources"
+        },
         "result": {
           "type": "string"
         }
@@ -60,6 +79,9 @@
           "items": {
             "$ref": "#/types/blocks:index/resourceAListOfResource:resourceAListOfResource"
           }
+        },
+        "aMapOfResources": {
+          "$ref": "#/types/blocks:index/resourceAMapOfResources:resourceAMapOfResources"
         }
       },
       "stateInputs": {
@@ -70,6 +92,9 @@
             "items": {
               "$ref": "#/types/blocks:index/resourceAListOfResource:resourceAListOfResource"
             }
+          },
+          "aMapOfResources": {
+            "$ref": "#/types/blocks:index/resourceAMapOfResources:resourceAMapOfResources"
           },
           "result": {
             "type": "string"
@@ -89,6 +114,9 @@
             "items": {
               "$ref": "#/types/blocks:index/dataSourceAListOfResource:dataSourceAListOfResource"
             }
+          },
+          "aMapOfResources": {
+            "$ref": "#/types/blocks:index/dataSourceAMapOfResources:dataSourceAMapOfResources"
           }
         },
         "type": "object"
@@ -101,6 +129,9 @@
             "items": {
               "$ref": "#/types/blocks:index/dataSourceAListOfResource:dataSourceAListOfResource"
             }
+          },
+          "aMapOfResources": {
+            "$ref": "#/types/blocks:index/dataSourceAMapOfResources:dataSourceAMapOfResources"
           },
           "id": {
             "type": "string",

--- a/pkg/convert/tf_scopes.go
+++ b/pkg/convert/tf_scopes.go
@@ -375,10 +375,18 @@ func (s *scopes) maxItemsOne(fullyQualifiedPath string) bool {
 		return *schemaInfo.MaxItemsOne
 	}
 
-	// If we have a shim schema use it's MaxItems
+	// If we have a shim schema use it's MaxItems and Type
 	sch := info.Schema
 	if sch != nil {
-		return sch.MaxItems() == 1
+		// If this is a list or set, check if it has a maxItems of 1.
+		if sch.Type() == shim.TypeList || sch.Type() == shim.TypeSet {
+			return sch.MaxItems() == 1
+		}
+		// If it's a map of resources then it's maxItems is 1
+		elem := sch.Elem()
+		if _, isResource := elem.(shim.Resource); sch.Type() == shim.TypeMap && isResource {
+			return true
+		}
 	}
 
 	// Else assume false


### PR DESCRIPTION
It was pointed out that in the TF shim schema an attribute that's typed
as a map but with a resource element should actually be treated as a
single object:
https://github.com/pulumi/pulumi-terraform-bridge/blob/f6e5260a88eab21043912e374bbafd5f42fd7f44/pkg/tfshim/shim.go#L149

This adds a test for schemas and programs of this shape.