### PR TITLE
Test list and map objects as attributes

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,3 +12,5 @@
 - Fix using a module multiple times via different constraints
 
 - Fix conversion of object blocks
+
+- Fix conversion of object attributes

--- a/pkg/convert/testdata/mappings/complex.json
+++ b/pkg/convert/testdata/mappings/complex.json
@@ -33,10 +33,22 @@
                         }
                     }
                 },
-                "inner_object": {
+                "inner_list_object": {
                     "type": 5,
                     "optional": true,
                     "maxItems": 1,
+                    "element": {
+                        "resource": {
+                            "inner_string": {
+                                "type": 4,
+                                "optional": true
+                            }
+                        }
+                    }
+                },
+                "inner_map_object": {
+                    "type": 6,
+                    "optional": true,
                     "element": {
                         "resource": {
                             "inner_string": {
@@ -84,10 +96,22 @@
                         }
                     }
                 },
-                "inner_object": {
+                "inner_list_object": {
                     "type": 5,
                     "optional": true,
                     "maxItems": 1,
+                    "element": {
+                        "resource": {
+                            "inner_string": {
+                                "type": 4,
+                                "optional": true
+                            }
+                        }
+                    }
+                },
+                "inner_map_object": {
+                    "type": 6,
+                    "optional": true,
                     "element": {
                         "resource": {
                             "inner_string": {

--- a/pkg/convert/testdata/programs/comments/main.tf
+++ b/pkg/convert/testdata/programs/comments/main.tf
@@ -25,7 +25,7 @@ data "complex_data_source" "a_data_source" {
         a: true
         b: false
     }
-    inner_object {
+    inner_map_object {
         // In objects
         inner_string = "hello again"
     }
@@ -43,7 +43,7 @@ resource "complex_resource" "a_resource" {
         a: true
         b: false
     }
-    inner_object {
+    inner_map_object {
         // In objects
         inner_string = "hello again"
     }

--- a/pkg/convert/testdata/programs/comments/pcl/main.pp
+++ b/pkg/convert/testdata/programs/comments/pcl/main.pp
@@ -23,7 +23,7 @@ aDataSource = invoke("complex:index/index:dataSource", {
     a = true
     b = false
   }
-  innerObject = {
+  innerMapObject = {
 
     // In objects
     innerString = "hello again"
@@ -43,7 +43,7 @@ resource "aResource" "complex:index/index:resource" {
     a = true
     b = false
   }
-  innerObject = {
+  innerMapObject = {
 
     // In objects
     innerString = "hello again"

--- a/pkg/convert/testdata/programs/complex_datasource/main.tf
+++ b/pkg/convert/testdata/programs/complex_datasource/main.tf
@@ -7,8 +7,11 @@ data "complex_data_source" "a_data_source" {
         a: true
         b: false
     }
-    inner_object {
+    inner_list_object = [{
         inner_string = "hello again"
+    }]
+    inner_map_object = {
+        inner_string = "hello thrice"
     }
 }
 

--- a/pkg/convert/testdata/programs/complex_datasource/pcl/main.pp
+++ b/pkg/convert/testdata/programs/complex_datasource/pcl/main.pp
@@ -7,8 +7,11 @@ aDataSource = invoke("complex:index/index:dataSource", {
     a = true
     b = false
   }
-  innerObject = {
+  innerListObject = {
     innerString = "hello again"
+  }
+  innerMapObject = {
+    innerString = "hello thrice"
   }
 })
 

--- a/pkg/convert/testdata/programs/complex_resource/main.tf
+++ b/pkg/convert/testdata/programs/complex_resource/main.tf
@@ -7,8 +7,11 @@ resource "complex_resource" "a_resource" {
         a: true
         b: false
     }
-    inner_object {
+    inner_list_object = [{
         inner_string = "hello again"
+    }]
+    inner_map_object = {
+        inner_string = "hello thrice"
     }
 }
 

--- a/pkg/convert/testdata/programs/complex_resource/pcl/main.pp
+++ b/pkg/convert/testdata/programs/complex_resource/pcl/main.pp
@@ -8,8 +8,11 @@ resource "aResource" "complex:index/index:resource" {
     a = true
     b = false
   }
-  innerObject = {
+  innerListObject = {
     innerString = "hello again"
+  }
+  innerMapObject = {
+    innerString = "hello thrice"
   }
 }
 

--- a/pkg/convert/testdata/programs/dotted/main.tf
+++ b/pkg/convert/testdata/programs/dotted/main.tf
@@ -1,5 +1,5 @@
 resource "complex_resource" "example" {
-    innerObject = {
+    innerMapObject = {
         noDots          = true
         ".dotted"       = true
         "dot.in.middle" = true

--- a/pkg/convert/testdata/programs/dotted/pcl/main.pp
+++ b/pkg/convert/testdata/programs/dotted/pcl/main.pp
@@ -1,5 +1,5 @@
 resource "example" "complex:index/index:resource" {
-  innerObject = {
+  innerMapObject = {
     noDots          = true
     ".dotted"       = true
     "dot.in.middle" = true

--- a/pkg/convert/testdata/schemas/complex.json
+++ b/pkg/convert/testdata/schemas/complex.json
@@ -18,7 +18,7 @@
   },
   "config": {},
   "types": {
-    "complex:index/dataSourceInnerObject:dataSourceInnerObject": {
+    "complex:index/dataSourceInnerListObject:dataSourceInnerListObject": {
       "properties": {
         "innerString": {
           "type": "string"
@@ -26,7 +26,23 @@
       },
       "type": "object"
     },
-    "complex:index/resourceInnerObject:resourceInnerObject": {
+    "complex:index/dataSourceInnerMapObject:dataSourceInnerMapObject": {
+      "properties": {
+        "innerString": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "complex:index/resourceInnerListObject:resourceInnerListObject": {
+      "properties": {
+        "innerString": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "complex:index/resourceInnerMapObject:resourceInnerMapObject": {
       "properties": {
         "innerString": {
           "type": "string"
@@ -62,8 +78,11 @@
         "aString": {
           "type": "string"
         },
-        "innerObject": {
-          "$ref": "#/types/complex:index/resourceInnerObject:resourceInnerObject"
+        "innerListObject": {
+          "$ref": "#/types/complex:index/resourceInnerListObject:resourceInnerListObject"
+        },
+        "innerMapObject": {
+          "$ref": "#/types/complex:index/resourceInnerMapObject:resourceInnerMapObject"
         },
         "result": {
           "type": "string"
@@ -94,8 +113,11 @@
         "aString": {
           "type": "string"
         },
-        "innerObject": {
-          "$ref": "#/types/complex:index/resourceInnerObject:resourceInnerObject"
+        "innerListObject": {
+          "$ref": "#/types/complex:index/resourceInnerListObject:resourceInnerListObject"
+        },
+        "innerMapObject": {
+          "$ref": "#/types/complex:index/resourceInnerMapObject:resourceInnerMapObject"
         }
       },
       "stateInputs": {
@@ -122,8 +144,11 @@
           "aString": {
             "type": "string"
           },
-          "innerObject": {
-            "$ref": "#/types/complex:index/resourceInnerObject:resourceInnerObject"
+          "innerListObject": {
+            "$ref": "#/types/complex:index/resourceInnerListObject:resourceInnerListObject"
+          },
+          "innerMapObject": {
+            "$ref": "#/types/complex:index/resourceInnerMapObject:resourceInnerMapObject"
           },
           "result": {
             "type": "string"
@@ -159,8 +184,11 @@
           "aString": {
             "type": "string"
           },
-          "innerObject": {
-            "$ref": "#/types/complex:index/dataSourceInnerObject:dataSourceInnerObject"
+          "innerListObject": {
+            "$ref": "#/types/complex:index/dataSourceInnerListObject:dataSourceInnerListObject"
+          },
+          "innerMapObject": {
+            "$ref": "#/types/complex:index/dataSourceInnerMapObject:dataSourceInnerMapObject"
           }
         },
         "type": "object"
@@ -193,8 +221,11 @@
             "type": "string",
             "description": "The provider-assigned unique ID for this managed resource.\n"
           },
-          "innerObject": {
-            "$ref": "#/types/complex:index/dataSourceInnerObject:dataSourceInnerObject"
+          "innerListObject": {
+            "$ref": "#/types/complex:index/dataSourceInnerListObject:dataSourceInnerListObject"
+          },
+          "innerMapObject": {
+            "$ref": "#/types/complex:index/dataSourceInnerMapObject:dataSourceInnerMapObject"
           },
           "result": {
             "type": "string"

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -1919,7 +1919,7 @@ func convertBody(state *convertState, scopes *scopes, fullyQualifiedPath string,
 			blockPath = appendPath(fullyQualifiedPath, block.Labels[0])
 		}
 		// If this is a list so add [] to the path
-		isList := !scopes.maxItemsOne(blockPath)
+		isList := !scopes.maxItemsOne(blockPath) && !scopes.isResource(blockPath)
 		name := scopes.pulumiName(blockPath)
 		if isList {
 			blockPath = appendPathArray(blockPath)

--- a/pkg/convert/tf_scopes.go
+++ b/pkg/convert/tf_scopes.go
@@ -345,21 +345,18 @@ func (s *scopes) isMap(fullyQualifiedPath string) *bool {
 	contract.Assertf(info.ResourceInfo == nil, "isMap called on a resource or data source")
 	contract.Assertf(info.DataSourceInfo == nil, "isMap called on a resource or data source")
 
-	// If we have a shim schema use the type from that
-	sch := info.Schema
-	if sch != nil {
-		// This is only an actual _map_ if the elem isn't a resource
-		_, resource := sch.Elem().(shim.Resource)
-		isMap := sch.Type() == shim.TypeMap && !resource
-		return &isMap
-	}
-
-	// If we have a Resource schema this must be an object
-	if info.Resource != nil {
+	// If this is a resource it's not a map
+	if s.isResource(fullyQualifiedPath) {
 		isMap := false
 		return &isMap
 	}
 
+	// If we have a shim schema use the type from that
+	sch := info.Schema
+	if sch != nil {
+		isMap := sch.Type() == shim.TypeMap
+		return &isMap
+	}
 	return nil
 }
 
@@ -380,6 +377,12 @@ func (s *scopes) isResource(fullyQualifiedPath string) bool {
 			return true
 		}
 	}
+
+	// If we have a Resource schema this must be an object
+	if info.Resource != nil {
+		return true
+	}
+
 	return false
 }
 

--- a/pkg/convert/tf_scopes.go
+++ b/pkg/convert/tf_scopes.go
@@ -316,8 +316,8 @@ func (s *scopes) pulumiName(fullyQualifiedPath string) string {
 	info := s.getInfo(fullyQualifiedPath)
 
 	// This should only be called for attribute paths, so panic if this returned a resource
-	contract.Assertf(info.ResourceInfo == nil, "pulumiName called on a resource or data source")
-	contract.Assertf(info.DataSourceInfo == nil, "pulumiName called on a resource or data source")
+	contract.Assertf(info.ResourceInfo == nil, "pulumiName must not be called on a resource or data source")
+	contract.Assertf(info.DataSourceInfo == nil, "pulumiName must not be called on a resource or data source")
 
 	// If we have a SchemaInfo and name use it
 	schemaInfo := info.SchemaInfo
@@ -342,8 +342,8 @@ func (s *scopes) isMap(fullyQualifiedPath string) *bool {
 	info := s.getInfo(fullyQualifiedPath)
 
 	// This should only be called for attribute paths, so panic if this returned a resource
-	contract.Assertf(info.ResourceInfo == nil, "isMap called on a resource or data source")
-	contract.Assertf(info.DataSourceInfo == nil, "isMap called on a resource or data source")
+	contract.Assertf(info.ResourceInfo == nil, "isMap must not be called on a resource or data source")
+	contract.Assertf(info.DataSourceInfo == nil, "isMap must not be called on a resource or data source")
 
 	// If this is a resource it's not a map
 	if s.isResource(fullyQualifiedPath) {
@@ -365,13 +365,14 @@ func (s *scopes) isResource(fullyQualifiedPath string) bool {
 	info := s.getInfo(fullyQualifiedPath)
 
 	// This should only be called for attribute paths, so panic if this returned a resource
-	contract.Assertf(info.ResourceInfo == nil, "maxItemsOne called on a resource or data source")
-	contract.Assertf(info.DataSourceInfo == nil, "maxItemsOne called on a resource or data source")
+	contract.Assertf(info.ResourceInfo == nil, "isResource must not be called on a resource or data source")
+	contract.Assertf(info.DataSourceInfo == nil, "isResource must not be called on a resource or data source")
 
-	// If we have a shim schema use it's MaxItems and Type
+	// If we have a shim schema use its MaxItems and Type
 	sch := info.Schema
 	if sch != nil {
-		// If it's a map of resources then return true
+		// If it's a map of resources then return true. Map of resource is used in TF schema to represent a
+		// sub-object, rather than a map of objects.
 		elem := sch.Elem()
 		if _, isResource := elem.(shim.Resource); sch.Type() == shim.TypeMap && isResource {
 			return true
@@ -391,8 +392,8 @@ func (s *scopes) maxItemsOne(fullyQualifiedPath string) bool {
 	info := s.getInfo(fullyQualifiedPath)
 
 	// This should only be called for attribute paths, so panic if this returned a resource
-	contract.Assertf(info.ResourceInfo == nil, "maxItemsOne called on a resource or data source")
-	contract.Assertf(info.DataSourceInfo == nil, "maxItemsOne called on a resource or data source")
+	contract.Assertf(info.ResourceInfo == nil, "maxItemsOne must not be called on a resource or data source")
+	contract.Assertf(info.DataSourceInfo == nil, "maxItemsOne must not be called on a resource or data source")
 
 	// If we have a SchemaInfo and a MaxItems override use it
 	schemaInfo := info.SchemaInfo
@@ -418,8 +419,8 @@ func (s *scopes) isAsset(fullyQualifiedPath string) *tfbridge.AssetTranslation {
 	info := s.getInfo(fullyQualifiedPath)
 
 	// This should only be called for attribute paths, so panic if this returned a resource
-	contract.Assertf(info.ResourceInfo == nil, "isAsset called on a resource or data source")
-	contract.Assertf(info.DataSourceInfo == nil, "isAsset called on a resource or data source")
+	contract.Assertf(info.ResourceInfo == nil, "isAsset must not be called on a resource or data source")
+	contract.Assertf(info.DataSourceInfo == nil, "isAsset must not be called on a resource or data source")
 
 	// If we have a SchemaInfo and a asset info return that
 	schemaInfo := info.SchemaInfo


### PR DESCRIPTION
List and map objects can be assigned as attributes or blocks. We had only really been testing them as blocks, both in the complex_X tests and also the list_as_blocks and maps_as_blocks tests.

This changes the complex_X tests to instead use attribute syntax, to test that works.

I've updated the complex schema to split the one "inner_object" field into "inner_list_object" and "inner_map_object". This required updating a couple of other tests that were using the complex resource to refer to "inner_list_object" instead of "inner_object".