### PR TITLE
Re-enabling compact for converter

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,6 +5,7 @@
 - Enable lookup which is already in pulumi-std
 - Enable merge which is already in pulumi-std
 - Enable flatten which is already in pulumi-std
+- Reenable "compact" since it is required for many providers.
 
 ### Bug Fixes
 

--- a/pkg/convert/testdata/programs/builtin_functions/pcl/diagnostics.json
+++ b/pkg/convert/testdata/programs/builtin_functions/pcl/diagnostics.json
@@ -24,7 +24,6 @@
   "warning:builtin_functions/main.tf:241,11-47:Function not yet implemented:Function coalescelist not yet implemented, see pulumi/pulumi-converter-terraform#65",
   "warning:builtin_functions/main.tf:244,11-39:Function not yet implemented:Function coalescelist not yet implemented, see pulumi/pulumi-converter-terraform#65",
   "warning:builtin_functions/main.tf:247,11-44:Function not yet implemented:Function coalescelist not yet implemented, see pulumi/pulumi-converter-terraform#65",
-  "warning:builtin_functions/main.tf:253,11-45:Function not yet implemented:Function compact not yet implemented, see pulumi/pulumi-converter-terraform#65",
   "warning:builtin_functions/main.tf:265,11-41:Function not yet implemented:Function contains not yet implemented, see pulumi/pulumi-converter-terraform#65 (catch all bug)",
   "warning:builtin_functions/main.tf:268,11-41:Function not yet implemented:Function contains not yet implemented, see pulumi/pulumi-converter-terraform#65 (catch all bug)",
   "warning:builtin_functions/main.tf:286,11-51:Function not yet implemented:Function distinct not yet implemented, see pulumi/pulumi-converter-terraform#65",

--- a/pkg/convert/testdata/programs/builtin_functions/pcl/main.pp
+++ b/pkg/convert/testdata/programs/builtin_functions/pcl/main.pp
@@ -337,7 +337,9 @@ output "funcCoalescelist2" {
 
 # Examples for compact
 output "funcCompact" {
-  value = notImplemented("compact([\"a\",\"\",\"b\",null,\"c\"])")
+  value = invoke("std:index:compact", {
+    input = ["a", "", "b", null, "c"]
+  }).result
 }
 
 

--- a/pkg/convert/testdata/schemas/std.json
+++ b/pkg/convert/testdata/schemas/std.json
@@ -546,13 +546,13 @@
       }
     },
     "std:index:compact": {
-      "description": "Removes empty string elements from a list.",
+      "description": "Removes empty and nil string elements from a list.",
       "inputs": {
         "properties": {
           "input": {
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref": "pulumi.json#/Any"
             }
           }
         },
@@ -564,16 +564,16 @@
       "outputs": {
         "properties": {
           "result": {
-            "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "type": "array"
           }
         },
-        "type": "object",
         "required": [
           "result"
-        ]
+        ],
+        "type": "object"
       }
     },
     "std:index:concat": {

--- a/pkg/convert/testdata/states/count/import.json
+++ b/pkg/convert/testdata/states/count/import.json
@@ -1,8 +1,8 @@
 [
   {
     "Type": "simple:index:resource",
-    "Name": "a_resource-0",
-    "ID": "abc123",
+    "Name": "a_resource-1",
+    "ID": "def456",
     "LogicalName": "",
     "IsComponent": false,
     "IsRemote": false,
@@ -11,8 +11,8 @@
   },
   {
     "Type": "simple:index:resource",
-    "Name": "a_resource-1",
-    "ID": "def456",
+    "Name": "a_resource-0",
+    "ID": "abc123",
     "LogicalName": "",
     "IsComponent": false,
     "IsRemote": false,

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -487,21 +487,13 @@ var tfFunctionStd = map[string]struct {
 		output:    "result",
 		paramArgs: true,
 	},
-	/* Currently failing due to: cannot assign expression of type { input: (string, string, string, null,
-	string) } to location of type { input: list(output(string) | string) | output(list(string)) } | output({
-	input: list(string) }):
-	*/
-	//
-	//	on main.pp line 263:
-	//	264:   value = invoke("std:index:compact", {
-	//	265:     input = ["a", "", "b", null, "c"]
-	//	266:   }).result
-	//
-	//"compact": {
-	//	token:  "std:index:compact",
-	//	inputs: []string{"input"},
-	//	output: "result",
-	//},
+	// TODO issue is this needs to support null
+	"compact": {
+		token:     "std:index:compact",
+		inputs:    []string{"input"},
+		output:    "result",
+		paramArgs: true,
+	},
 	"cidrhost": {
 		token:  "std:index:cidrhost",
 		inputs: []string{"input", "host"},
@@ -3595,7 +3587,6 @@ func componentProgramBinderFromAfero(fs afero.Fs) pcl.ComponentProgramBinder {
 var unimplementedFunctionBugs = map[string]string{
 	"coalesce":     "pulumi/pulumi-converter-terraform#65",
 	"coalescelist": "pulumi/pulumi-converter-terraform#65",
-	"compact":      "pulumi/pulumi-converter-terraform#65",
 	"distinct":     "pulumi/pulumi-converter-terraform#65",
 	"format":       "pulumi/pulumi-converter-terraform#65",
 	"formatdate":   "pulumi/pulumi-converter-terraform#196",


### PR DESCRIPTION
Compact is disabled but in local testing trying to make convert more powerful this seems to work.

Reenabling for now because it is not working with or without it anyway

Blocked by pulumi/pulumi-std#76
Blocked by pulumi/pulumi-std#77

Related #65
Fixes pulumi/pulumi#18406
