### PR TITLE
Implement the `compact` function

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -6,6 +6,7 @@
 - Enable merge which is already in pulumi-std
 - Enable flatten which is already in pulumi-std
 - Implement `coalesce` through the `pulumi-std` invoke of the same name
+- Implement `compact` through the `pulumi-std` invoke of the same name
 
 ### Bug Fixes
 

--- a/pkg/convert/testdata/programs/builtin_functions/pcl/diagnostics.json
+++ b/pkg/convert/testdata/programs/builtin_functions/pcl/diagnostics.json
@@ -17,7 +17,6 @@
   "warning:builtin_functions/main.tf:241,11-47:Function not yet implemented:Function coalescelist not yet implemented, see pulumi/pulumi-converter-terraform#65",
   "warning:builtin_functions/main.tf:244,11-39:Function not yet implemented:Function coalescelist not yet implemented, see pulumi/pulumi-converter-terraform#65",
   "warning:builtin_functions/main.tf:247,11-44:Function not yet implemented:Function coalescelist not yet implemented, see pulumi/pulumi-converter-terraform#65",
-  "warning:builtin_functions/main.tf:253,11-45:Function not yet implemented:Function compact not yet implemented, see pulumi/pulumi-converter-terraform#65",
   "warning:builtin_functions/main.tf:265,11-41:Function not yet implemented:Function contains not yet implemented, see pulumi/pulumi-converter-terraform#65 (catch all bug)",
   "warning:builtin_functions/main.tf:268,11-41:Function not yet implemented:Function contains not yet implemented, see pulumi/pulumi-converter-terraform#65 (catch all bug)",
   "warning:builtin_functions/main.tf:286,11-51:Function not yet implemented:Function distinct not yet implemented, see pulumi/pulumi-converter-terraform#65",

--- a/pkg/convert/testdata/programs/builtin_functions/pcl/main.pp
+++ b/pkg/convert/testdata/programs/builtin_functions/pcl/main.pp
@@ -351,7 +351,9 @@ output "funcCoalescelist2" {
 
 # Examples for compact
 output "funcCompact" {
-  value = notImplemented("compact([\"a\",\"\",\"b\",null,\"c\"])")
+  value = invoke("std:index:compact", {
+    input = ["a", "", "b", null, "c"]
+  }).result
 }
 
 

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -493,21 +493,11 @@ var tfFunctionStd = map[string]struct {
 		output:    "result",
 		paramArgs: true,
 	},
-	/* Currently failing due to: cannot assign expression of type { input: (string, string, string, null,
-	string) } to location of type { input: list(output(string) | string) | output(list(string)) } | output({
-	input: list(string) }):
-	*/
-	//
-	//	on main.pp line 263:
-	//	264:   value = invoke("std:index:compact", {
-	//	265:     input = ["a", "", "b", null, "c"]
-	//	266:   }).result
-	//
-	//"compact": {
-	//	token:  "std:index:compact",
-	//	inputs: []string{"input"},
-	//	output: "result",
-	//},
+	"compact": {
+		token:  "std:index:compact",
+		inputs: []string{"input"},
+		output: "result",
+	},
 	"cidrhost": {
 		token:  "std:index:cidrhost",
 		inputs: []string{"input", "host"},
@@ -3600,7 +3590,6 @@ func componentProgramBinderFromAfero(fs afero.Fs) pcl.ComponentProgramBinder {
 
 var unimplementedFunctionBugs = map[string]string{
 	"coalescelist": "pulumi/pulumi-converter-terraform#65",
-	"compact":      "pulumi/pulumi-converter-terraform#65",
 	"distinct":     "pulumi/pulumi-converter-terraform#65",
 	"format":       "pulumi/pulumi-converter-terraform#65",
 	"formatdate":   "pulumi/pulumi-converter-terraform#196",


### PR DESCRIPTION
This should be implemented in the newly released `pulumi-std` 2.1.0, so we can start generating invoke calls for it.

Fixes pulumi/pulumi#18406