### PR TITLE
Implement the `setintersection` function

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,5 +11,6 @@
 - Implement `distinct` through the `pulumi-std` invoke of the same name
 - Implement `format` through the `pulumi-std` invoke of the same name
 - Implement `keys` through the `pulumi-std` invoke of the same name
+- Implement `setintersection` through the `pulumi-std` invoke of the same name
 
 ### Bug Fixes

--- a/pkg/convert/testdata/programs/builtin_functions/pcl/diagnostics.json
+++ b/pkg/convert/testdata/programs/builtin_functions/pcl/diagnostics.json
@@ -55,7 +55,6 @@
   "warning:builtin_functions/main.tf:757,18-57:Function not yet implemented:Function regexall not yet implemented, see pulumi/pulumi-converter-terraform#191",
   "warning:builtin_functions/main.tf:760,18-49:Function not yet implemented:Function regexall not yet implemented, see pulumi/pulumi-converter-terraform#191",
   "warning:builtin_functions/main.tf:775,11-29:Function not yet implemented:Function reverse not yet implemented, see pulumi/pulumi-converter-terraform#65 (catch all bug)",
-  "warning:builtin_functions/main.tf:799,11-62:Function not yet implemented:Function setintersection not yet implemented, see pulumi/pulumi-converter-terraform#65 (catch all bug)",
   "warning:builtin_functions/main.tf:805,11-67:Function not yet implemented:Function setproduct not yet implemented, see pulumi/pulumi-converter-terraform#65 (catch all bug)",
   "warning:builtin_functions/main.tf:808,11-35:Function not yet implemented:Function setproduct not yet implemented, see pulumi/pulumi-converter-terraform#65 (catch all bug)",
   "warning:builtin_functions/main.tf:811,11-58:Function not yet implemented:Function setproduct not yet implemented, see pulumi/pulumi-converter-terraform#65 (catch all bug)",

--- a/pkg/convert/testdata/programs/builtin_functions/pcl/main.pp
+++ b/pkg/convert/testdata/programs/builtin_functions/pcl/main.pp
@@ -1202,7 +1202,9 @@ output "funcSensitive2" {
 
 # Examples for setintersection
 output "funcSetintersection" {
-  value = notImplemented("setintersection([\"a\",\"b\"],[\"b\",\"c\"],[\"b\",\"d\"])")
+  value = invoke("std:index:setintersection", {
+    input = [["a", "b"], ["b", "c"], ["b", "d"]]
+  }).result
 }
 
 

--- a/pkg/convert/testdata/schemas/std.json
+++ b/pkg/convert/testdata/schemas/std.json
@@ -1785,6 +1785,40 @@
         "type": "object"
       }
     },
+    "std:index:setintersection": {
+      "description": "Returns the set of elements that all the input sets have in common.",
+      "inputs": {
+        "properties": {
+          "input": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "pulumi.json#/Any"
+              }
+            }
+          }
+        },
+        "type": "object",
+        "required": [
+          "input"
+        ]
+      },
+      "outputs": {
+        "properties": {
+          "result": {
+            "items": {
+              "$ref": "pulumi.json#/Any"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object"
+      }
+    },
     "std:index:sha1": {
       "description": "Returns a hexadecimal representation of the SHA-1 hash of the given string.",
       "inputs": {

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -693,6 +693,12 @@ var tfFunctionStd = map[string]struct {
 		inputs: []string{"cipherText", "key"},
 		output: "result",
 	},
+	"setintersection": {
+		token:     "std:index:setintersection",
+		inputs:    []string{"input"},
+		output:    "result",
+		paramArgs: true,
+	},
 	"sha1": {
 		token:  "std:index:sha1",
 		inputs: []string{"input"},


### PR DESCRIPTION
This should be implemented in the newly released `pulumi-std` 2.2.0, so
we can start generating invoke calls for it.

blocked by pulumi/pulumi-std#89

related #65
Fixes pulumi/pulumi#18518
