### PR TITLE
Clean up formatting and linting

### DIFF
--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -26,31 +26,20 @@ jobs:
         with:
           go-version: 1.22.x
       - run: go mod tidy
-      - name: Fail if god mod not tidy
+      - name: Fail if go.mod not tidy
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             echo "::error go.mod not tidy"
             exit 1
           fi
-      - name: Lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.49.0
-          make lint-golang || true
 
-  check-copyright:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
+      # We leverage the golangci-lint action to install and maintain the cache, but we want to run the command
+      # ourselves. The action doesn't have an install-only mode, so we'll ask it to print its help output instead.
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v4
         with:
-          ref: ${{ inputs.commit-ref }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Set up Go 1.22.x
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.22.x
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          args: --help
+
       - name: Lint
-        run: make lint-copyright
+        run: make lint GOLANGCI_LINT_ARGS=--out-format=colored-line-number

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,21 +3,93 @@ run:
 linters:
   enable-all: false
   enable:
-    - deadcode
+    - durationcheck
+    - depguard
     - errcheck
-    - goconst
-    - gofmt
-    - revive
+    - exhaustive
+    - gofumpt
+    - goheader
+    - goprintffuncname
     - gosec
     - govet
+    - importas
     - ineffassign
+    - lll
     - misspell
     - nakedret
-    - structcheck
-    - unconvert
-    - varcheck
+    - nolintlint
     - paralleltest
-  disable:
-    - lll
-    - staticcheck # Disabled due to OOM errors in golangci-lint@v1.18.0
-    - megacheck # Disabled due to OOM errors in golangci-lint@v1.18.0
+    - perfsprint
+    - prealloc
+    - revive
+    - tenv
+    - unconvert
+    - unused
+    - wastedassign
+    - whitespace
+
+linters-settings:
+  nakedret:
+    # Make an issue if func has more lines of code than this setting, and it has naked returns.
+    # Default: 30
+    max-func-lines: 60
+  nolintlint:
+    # Some linter exclusions are added to generated or templated files
+    # pre-emptively.
+    # Don't complain about these.
+    allow-unused: true
+  govet:
+    enable:
+      - nilness
+      # Reject comparisons of reflect.Value with DeepEqual or '=='.
+      - reflectvaluecompare
+      # Reject sort.Slice calls with a non-slice argument.
+      - sortslice
+      # Detect write to struct/arrays by-value that aren't read again.
+      - unusedwrite
+  depguard:
+    rules:
+      protobuf:
+        deny:
+          - pkg: "github.com/golang/protobuf"
+            desc: Use google.golang.org/protobuf instead
+  goheader:
+    values:
+      regexp:
+        COPYRIGHT_YEARS: (\d{4}-)?\d{4}
+        WHITESPACE: \s*
+    template: |-
+      Copyright {{ COPYRIGHT_YEARS }}, Pulumi Corporation.
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+      {{ WHITESPACE }}http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+issues:
+  exclude-rules:
+    # Don't warn on unused parameters.
+    # Parameter names are useful; replacing them with '_' is undesirable.
+    - linters: [revive]
+      text: 'unused-parameter: parameter \S+ seems to be unused, consider removing or renaming it as _'
+
+    # staticcheck already has smarter checks for empty blocks.
+    # revive's empty-block linter has false positives.
+    # For example, as of writing this, the following is not allowed.
+    #   for foo() { }
+    - linters: [revive]
+      text: 'empty-block: this block is empty, you can remove it'
+
+    # We *frequently* use the term 'new' in the context of properties
+    # (new and old properties),
+    # and we rarely use the 'new' built-in function.
+    # It's fine to ignore these cases.
+    - linters: [revive]
+      text: 'redefines-builtin-id: redefinition of the built-in function new'

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,20 @@ VERSION         ?= $(shell pulumictl get version)
 VERSION_PATH    := pkg/version.Version
 WORKING_DIR     := $(shell pwd)
 TESTPARALLELISM := 4
-GOPATH			:= $(shell go env GOPATH)
+GOPATH          := $(shell go env GOPATH)
+#
+# Additional arguments to pass to golangci-lint.
+GOLANGCI_LINT_ARGS ?=
 
 ensure::
 	go mod tidy
 
-lint::
-	cd "pkg" && golangci-lint run -c ../.golangci.yml --timeout 10m
-	cd "cmd" && golangci-lint run -c ../.golangci.yml --timeout 10m
+format::
+	gofumpt -w cmd pkg
 
-lint-copyright:
-	pulumictl copyright
+lint::
+	cd "pkg" && golangci-lint run $(GOLANGCI_LINT_ARGS) -c ../.golangci.yml --timeout 10m
+	cd "cmd" && golangci-lint run $(GOLANGCI_LINT_ARGS) -c ../.golangci.yml --timeout 10m
 
 build::
 	(cd cmd && go build -o $(WORKING_DIR)/bin/${BINARY} -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION}" $(PROJECT)/cmd/$(BINARY))

--- a/cmd/pulumi-converter-terraform/main.go
+++ b/cmd/pulumi-converter-terraform/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -50,7 +51,7 @@ func (*tfConverter) ConvertState(_ context.Context,
 	providerInfoSource := il.NewMapperProviderInfoSource(mapper)
 
 	if len(req.Args) != 1 {
-		return nil, fmt.Errorf("expected exactly one argument")
+		return nil, errors.New("expected exactly one argument")
 	}
 	path := req.Args[0]
 

--- a/cmd/pulumi-converter-terraform/main_test.go
+++ b/cmd/pulumi-converter-terraform/main_test.go
@@ -88,7 +88,9 @@ func TestExamplesJson(t *testing.T) {
 				map[string]interface{}{
 					"Severity": 2.0,
 					"Summary":  "Failed to get provider info",
-					"Detail":   "Failed to get provider info for \"aws_bucket\": could not find mapping information for provider aws; try installing a pulumi plugin that supports this terraform provider",
+					"Detail": "Failed to get provider info for \"aws_bucket\": " +
+						"could not find mapping information for provider aws; " +
+						"try installing a pulumi plugin that supports this terraform provider",
 					"Subject": map[string]interface{}{
 						"Filename": "/aws.tf",
 						"Start":    map[string]interface{}{"Line": 1.0, "Column": 1.0, "Byte": 0.0},

--- a/cmd/pulumi-converter-terraform/par.go
+++ b/cmd/pulumi-converter-terraform/par.go
@@ -26,7 +26,6 @@ func parTransformMapWith[K comparable, T any, U any](
 	transform func(K, T) (U, error),
 	workers int,
 ) (map[K]U, error) {
-
 	n := workers
 	if workers < 1 {
 		n = runtime.NumCPU()

--- a/cmd/pulumi-converter-terraform/par_test.go
+++ b/cmd/pulumi-converter-terraform/par_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -23,6 +24,7 @@ import (
 )
 
 func TestParTransformMap(t *testing.T) {
+	t.Parallel()
 
 	mkMap := func(n int) map[int]int {
 		m := map[int]int{}
@@ -44,7 +46,7 @@ func TestParTransformMap(t *testing.T) {
 
 	increment := func(k, v int) (int, error) {
 		if v < 0 {
-			return 0, fmt.Errorf("neg")
+			return 0, errors.New("neg")
 		}
 		return v + 1, nil
 	}
@@ -62,6 +64,8 @@ func TestParTransformMap(t *testing.T) {
 		tc := tc
 
 		t.Run(fmt.Sprintf("w%d", tc.workers), func(t *testing.T) {
+			t.Parallel()
+
 			var ops atomic.Uint64
 
 			inc := func(k, v int) (int, error) {
@@ -71,6 +75,7 @@ func TestParTransformMap(t *testing.T) {
 
 			actual, actualErr := parTransformMapWith(tc.inputs, inc, tc.workers)
 			expect, expectErr := apply(increment, tc.inputs)
+			//nolint:gosec
 			assert.Equal(t, len(tc.inputs), int(ops.Load()))
 			assert.Equal(t, expectErr == nil, actualErr == nil)
 			assert.Equal(t, expect, actual)

--- a/pkg/convert/model_helpers.go
+++ b/pkg/convert/model_helpers.go
@@ -19,9 +19,10 @@
 package convert
 
 import (
+	"errors"
 	"fmt"
+
 	"github.com/hashicorp/hcl/v2"
-	//"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 )
@@ -45,11 +46,11 @@ import (
 // case.
 func setConfigBlockType(block *model.Block, variableType model.Type) error {
 	if block.Type != "config" {
-		return fmt.Errorf("setConfigBlockType should only be used on block.Type='config' blocks")
+		return errors.New("setConfigBlockType should only be used on block.Type='config' blocks")
 	}
 
 	if len(block.Labels) >= 2 {
-		return fmt.Errorf("setConfigBlockType refuses to overwrite block.Label[1]")
+		return errors.New("setConfigBlockType refuses to overwrite block.Label[1]")
 	}
 
 	tempScope := model.TypeScope.Push(nil)

--- a/pkg/convert/model_helpers_test.go
+++ b/pkg/convert/model_helpers_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestSetConfigBlockType(t *testing.T) {
+	t.Parallel()
+
 	check := func(name string, ty model.Type, expectError bool) {
 		t.Run(name, func(t *testing.T) {
 			block := &model.Block{Type: "config", Labels: []string{"x"}}
@@ -62,6 +64,8 @@ func TestSetConfigBlockType(t *testing.T) {
 }
 
 func TestGeneralizeConstType(t *testing.T) {
+	t.Parallel()
+
 	constType := model.NewConstType(model.IntType, cty.NumberIntVal(1))
 	assert.True(t, generalizeConstType(constType).Equals(model.IntType))
 

--- a/pkg/convert/pulumiverse.go
+++ b/pkg/convert/pulumiverse.go
@@ -1,4 +1,16 @@
-// Copyright 2024, Pulumi Corporation.  All rights reserved.
+// Copyright 2024-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package convert
 

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -421,9 +421,9 @@ var tfFunctionRenames = map[string]string{
 }
 
 var tfFunctionStd = map[string]struct {
-	token     string
-	inputs    []string
-	output    string
+	token  string
+	inputs []string
+	output string
 
 	// True if and only if the function has a variable number of arguments. If this is the case, these arguments will be
 	// packed into a single list in order to be passed to the relevant `pulumi-std` invoke, since invokes do not support
@@ -442,12 +442,12 @@ var tfFunctionStd = map[string]struct {
 		output: "result",
 	},
 	"alltrue": {
-		token:	"std:index:alltrue",
+		token:  "std:index:alltrue",
 		inputs: []string{"input"},
 		output: "result",
 	},
 	"anytrue": {
-		token:	"std:index:anytrue",
+		token:  "std:index:anytrue",
 		inputs: []string{"input"},
 		output: "result",
 	},
@@ -620,9 +620,9 @@ var tfFunctionStd = map[string]struct {
 		output: "result",
 	},
 	"format": {
-		token:	"std:index:format",
-		inputs: []string{"input", "args"},
-		output: "result",
+		token:     "std:index:format",
+		inputs:    []string{"input", "args"},
+		output:    "result",
 		paramArgs: true,
 	},
 	"indent": {
@@ -641,7 +641,7 @@ var tfFunctionStd = map[string]struct {
 		output: "result",
 	},
 	"keys": {
-		token: "std:index:keys",
+		token:  "std:index:keys",
 		inputs: []string{"input"},
 		output: "result",
 	},
@@ -651,7 +651,7 @@ var tfFunctionStd = map[string]struct {
 		output: "result",
 	},
 	"lookup": {
-		token: "std:index:lookup",
+		token:  "std:index:lookup",
 		inputs: []string{"map", "key", "default"},
 		output: "result",
 	},
@@ -672,9 +672,9 @@ var tfFunctionStd = map[string]struct {
 		output: "result",
 	},
 	"merge": {
-		token:  "std:index:merge",
-		inputs: []string{"input"},
-		output: "result",
+		token:     "std:index:merge",
+		inputs:    []string{"input"},
+		output:    "result",
 		paramArgs: true,
 	},
 	"min": {
@@ -740,7 +740,7 @@ var tfFunctionStd = map[string]struct {
 		output: "result",
 	},
 	"slice": {
-		token: "std:index:slice",
+		token:  "std:index:slice",
 		inputs: []string{"list", "from", "to"},
 		output: "result",
 	},
@@ -881,7 +881,12 @@ func (s *convertState) sourceCode(rng hcl.Range) string {
 	return strings.Replace(buffer.String(), "\r\n", "\n", -1)
 }
 
-func (s *convertState) renamePclOverlap(kind string, hclType *string, name string, hclRange *hcl.Range) (string, string) {
+func (s *convertState) renamePclOverlap(
+	kind string,
+	hclType *string,
+	name string,
+	hclRange *hcl.Range,
+) (string, string) {
 	newName := name
 	newType := new(string)
 	if hclType != nil {
@@ -1110,7 +1115,8 @@ func appendPathArray(root string) string {
 	return root + "[]"
 }
 
-// matchStaticString returns a literal string if the expression is a static string or identifier, else nil. It returns true if this was an identifier.
+// matchStaticString returns a literal string if the expression is a static string or identifier, else nil. It returns
+// true if this was an identifier.
 func matchStaticString(expr hclsyntax.Expression) (*string, bool) {
 	switch expr := expr.(type) {
 	case *hclsyntax.ObjectConsKeyExpr:
@@ -1351,7 +1357,7 @@ func convertTemplateExpr(state *convertState,
 		}
 	}
 	if isHereDoc {
-		tokens = append(tokens, makeToken(hclsyntax.TokenCHeredoc, fmt.Sprintf("\n%s", cDelim)))
+		tokens = append(tokens, makeToken(hclsyntax.TokenCHeredoc, "\n"+cDelim))
 	} else {
 		tokens = append(tokens, makeToken(hclsyntax.TokenCQuote, "\""))
 	}
@@ -2424,7 +2430,7 @@ func convertProvisioner(
 		target.AppendUnstructuredTokens(hclwrite.Tokens{
 			&hclwrite.Token{
 				Type:  hclsyntax.TokenComment,
-				Bytes: []byte(fmt.Sprintf("// Unsupported provisioner type %s", provisioner.Type)),
+				Bytes: []byte("// Unsupported provisioner type " + provisioner.Type),
 			},
 		})
 		return
@@ -2532,9 +2538,7 @@ func convertManagedResources(state *convertState,
 	var options *hclwrite.Block
 	// Does this resource have dependencies? If so set the "dependsOn" attribute
 	if len(managedResource.DependsOn) > 0 {
-		if options == nil {
-			options = hclwrite.NewBlock("options", nil)
-		}
+		options = hclwrite.NewBlock("options", nil)
 		dependsOn := hclwrite.Tokens{makeToken(hclsyntax.TokenOBrack, "[")}
 		for idx, dep := range managedResource.DependsOn {
 			if idx > 0 {
@@ -2739,9 +2743,8 @@ func (items terraformItems) Less(i, j int) bool {
 		return true
 	} else if a.Filename > b.Filename {
 		return false
-	} else {
-		return a.Start.Line < b.Start.Line
 	}
+	return a.Start.Line < b.Start.Line
 }
 
 // Used to key into the modules map for the given address and version.
@@ -2954,6 +2957,7 @@ func translateModuleSourceCode(
 				invokeToken = root.DataSourceInfo.Tok.String()
 			}
 			tokenParts := strings.Split(invokeToken, ":")
+			//nolint:staticcheck
 			suffix := strings.Title(tokenParts[len(tokenParts)-1])
 			root.Name = scopes.getOrAddPulumiName(key, "", suffix)
 			scopes.roots[key] = root
@@ -2986,6 +2990,7 @@ func translateModuleSourceCode(
 				resourceToken = root.ResourceInfo.Tok.String()
 			}
 			tokenParts := strings.Split(resourceToken, ":")
+			//nolint:staticcheck
 			suffix := strings.Title(tokenParts[len(tokenParts)-1])
 			root.Name = scopes.getOrAddPulumiName(key, "", suffix)
 			scopes.roots[key] = root
@@ -3129,7 +3134,8 @@ func translateModuleSourceCode(
 						return state.diagnostics
 					}
 
-					// At this point we have a real version, we're going to resolve our module key to _that_ version and look it up again
+					// At this point we have a real version, we're going to resolve our module key to _that_ version and look it
+					// up again
 					absoluteKey := moduleKey.WithVersion(latestVersion.String())
 					if _, has := modules[absoluteKey]; has {
 						// We've seen this before, we can just use that path
@@ -3194,7 +3200,7 @@ func translateModuleSourceCode(
 							return state.diagnostics
 						}
 					}
-					// Update both our origional key, and the resolved absolute key to point to this created path
+					// Update both our original key, and the resolved absolute key to point to this created path
 					modules[moduleKey] = destinationPath
 					modules[absoluteKey] = destinationPath
 
@@ -3523,9 +3529,9 @@ func getPackageBlock(name string, prov *configs.RequiredProvider) (*hclwrite.Blo
 	packageNameParts := strings.Split(prov.Source, "/")
 	packageName := packageNameParts[len(packageNameParts)-1]
 
-	// TODO(pulumi/pulumi#17933) For now we just the package name portion of the source (also known as the "type" in tf parlance).
-	// This may lead to name overlap, but as of now this is how our system works.
-	// If we need to fix name overlap, this is the place to start.
+	// TODO(pulumi/pulumi#17933) For now we just the package name portion of the source (also known as the "type" in tf
+	// parlance). This may lead to name overlap, but as of now this is how our system works. If we need to fix name
+	// overlap, this is the place to start.
 	_ = name
 	block := hclwrite.NewBlock("package", []string{packageName})
 	body := block.Body()
@@ -3613,12 +3619,12 @@ func componentProgramBinderFromAfero(fs afero.Fs) pcl.ComponentProgramBinder {
 		// Load all .pp files in the components' directory
 		files, err := afero.ReadDir(fs, componentSourceDir)
 		if err != nil {
-			diagnostics = diagnostics.Append(errorf(nodeRange, err.Error()))
+			diagnostics = diagnostics.Append(errorf(nodeRange, "%s", err.Error()))
 			return nil, diagnostics, nil
 		}
 
 		if len(files) == 0 {
-			diagnostics = diagnostics.Append(errorf(nodeRange, err.Error()))
+			diagnostics = diagnostics.Append(errorf(nodeRange, "no .pp files found"))
 			return nil, diagnostics, nil
 		}
 
@@ -3632,13 +3638,13 @@ func componentProgramBinderFromAfero(fs afero.Fs) pcl.ComponentProgramBinder {
 			if filepath.Ext(fileName) == ".pp" {
 				file, err := fs.Open(path)
 				if err != nil {
-					diagnostics = diagnostics.Append(errorf(nodeRange, err.Error()))
+					diagnostics = diagnostics.Append(errorf(nodeRange, "%s", err.Error()))
 					return nil, diagnostics, err
 				}
 
 				err = parser.ParseFile(file, fileName)
 				if err != nil {
-					diagnostics = diagnostics.Append(errorf(nodeRange, err.Error()))
+					diagnostics = diagnostics.Append(errorf(nodeRange, "%s", err.Error()))
 					return nil, diagnostics, err
 				}
 
@@ -3647,11 +3653,6 @@ func componentProgramBinderFromAfero(fs afero.Fs) pcl.ComponentProgramBinder {
 					return nil, diagnostics, err
 				}
 			}
-		}
-
-		if err != nil {
-			diagnostics = diagnostics.Append(errorf(nodeRange, err.Error()))
-			return nil, diagnostics, err
 		}
 
 		componentProgram, programDiags, err := pcl.BindProgram(parser.Files,

--- a/pkg/convert/tf_scopes.go
+++ b/pkg/convert/tf_scopes.go
@@ -286,7 +286,6 @@ func (s *scopes) getInfo(fullyQualifiedPath string) PathInfo {
 		}
 
 		return getInner(currentSchema, currentInfo, parts[3:])
-
 	}
 
 	root, has := s.roots[parts[0]+"."+parts[1]]

--- a/pkg/convert/tf_state.go
+++ b/pkg/convert/tf_state.go
@@ -145,7 +145,7 @@ func TranslateState(info il.ProviderInfoSource, path string) (*plugin.ConvertSta
 						if err != nil {
 							return nil, err
 						}
-						resourceId, err := getString(resource.Addr.Resource, obj, "resource_id")
+						resourceID, err := getString(resource.Addr.Resource, obj, "resource_id")
 						if err != nil {
 							return nil, err
 						}
@@ -158,13 +158,13 @@ func TranslateState(info il.ProviderInfoSource, path string) (*plugin.ConvertSta
 							return nil, err
 						}
 
-						id = fmt.Sprintf("%s/%s/%s/%s", serviceNamespace, resourceId, scalableDimension, name)
+						id = fmt.Sprintf("%s/%s/%s/%s", serviceNamespace, resourceID, scalableDimension, name)
 					case "aws_appautoscaling_target":
 						serviceNamespace, err := getString(resource.Addr.Resource, obj, "service_namespace")
 						if err != nil {
 							return nil, err
 						}
-						resourceId, err := getString(resource.Addr.Resource, obj, "resource_id")
+						resourceID, err := getString(resource.Addr.Resource, obj, "resource_id")
 						if err != nil {
 							return nil, err
 						}
@@ -173,7 +173,7 @@ func TranslateState(info il.ProviderInfoSource, path string) (*plugin.ConvertSta
 							return nil, err
 						}
 
-						id = fmt.Sprintf("%s/%s/%s", serviceNamespace, resourceId, scalableDimension)
+						id = fmt.Sprintf("%s/%s/%s", serviceNamespace, resourceID, scalableDimension)
 					default:
 						// We only care about the id value
 						id, err = getString(resource.Addr.Resource, obj, "id")

--- a/pkg/convert/tf_state_test.go
+++ b/pkg/convert/tf_state_test.go
@@ -33,6 +33,8 @@ import (
 // TestTranslateState runs through all the folders in testdata and tries to convert their tfstate.json file to
 // a pulumi import response.
 func TestTranslateState(t *testing.T) {
+	t.Parallel()
+
 	// Test framework for TranslateState
 	// Each folder in testdata has a tfstate.json file and a .json file with the expected output
 	testDir, err := filepath.Abs(filepath.Join("testdata"))

--- a/pkg/convert/tf_trivia_test.go
+++ b/pkg/convert/tf_trivia_test.go
@@ -74,8 +74,9 @@ func TestGetTriviaFromIndex(t *testing.T) {
 
 	for _, tt := range cases {
 		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
-			//t.Parallel()
+			t.Parallel()
 
 			tokens, diagnostics := hclsyntax.LexConfig([]byte(tt.input), "", hcl.Pos{Byte: 0, Line: 1, Column: 1})
 			assert.Empty(t, diagnostics)

--- a/pkg/il/mapper.go
+++ b/pkg/il/mapper.go
@@ -43,9 +43,11 @@ func (mapper *mapperProviderInfoSource) GetProviderInfo(
 	}
 	// Might be nil or []
 	if len(data) == 0 {
-		message := fmt.Sprintf("could not find mapping information for provider %s", name)
-		message += "; try installing a pulumi plugin that supports this terraform provider"
-		return nil, fmt.Errorf(message)
+		return nil, fmt.Errorf(
+			"could not find mapping information for provider %s; "+
+				"try installing a pulumi plugin that supports this terraform provider",
+			name,
+		)
 	}
 
 	var info *tfbridge.MarshallableProviderInfo

--- a/pkg/testing/schemas.go
+++ b/pkg/testing/schemas.go
@@ -24,7 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// If zeroValue is non-nil it's used if a JSON file is missing. This saves us having to keep a load of diagnostic.json files with just "[]" in them.
+// If zeroValue is non-nil it's used if a JSON file is missing. This saves us having to keep a load of diagnostic.json
+// files with just "[]" in them.
 func AssertEqualsJSONFile[T any](
 	t *testing.T,
 	expectedJSONFile string,


### PR DESCRIPTION
As pointed out by @daveset in #296, linting hasn't been working on this repository for a while, and formatting is a bit all over the place. This change turns linting back on, removes deprecated linters and copies the "big set" we use in `pulumi/pulumi`. With that we can clean it all up, turn CI checks back on and deprecate a few other bits (e.g. linting now takes care of copyright checks for us).