### PR TITLE
Fix substr calls

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,3 +18,5 @@
 - Implement `chunklist` through the `pulumi-std` invoke of the same name
 
 ### Bug Fixes
+
+- Fix the order of arguments to `substr`

--- a/pkg/convert/testdata/programs/builtin_functions/pcl/main.pp
+++ b/pkg/convert/testdata/programs/builtin_functions/pcl/main.pp
@@ -1396,29 +1396,29 @@ output "funcStrrev1" {
 output "funcSubstr0" {
   value = invoke("std:index:substr", {
     input  = "hello world"
-    length = 1
-    offset = 4
+    offset = 1
+    length = 4
   }).result
 }
 output "funcSubstr1" {
   value = invoke("std:index:substr", {
     input  = "🤔🤷"
-    length = 0
-    offset = 1
+    offset = 0
+    length = 1
   }).result
 }
 output "funcSubstr2" {
   value = invoke("std:index:substr", {
     input  = "hello world"
-    length = -5
-    offset = -1
+    offset = -5
+    length = -1
   }).result
 }
 output "funcSubstr3" {
   value = invoke("std:index:substr", {
     input  = "hello world"
-    length = 6
-    offset = 10
+    offset = 6
+    length = 10
   }).result
 }
 

--- a/pkg/convert/testdata/programs/registry_module_multiple_versions/pcl/dir_1.0.0/files.pp
+++ b/pkg/convert/testdata/programs/registry_module_multiple_versions/pcl/dir_1.0.0/files.pp
@@ -2,8 +2,8 @@ allFilePaths    = notImplemented("fileset(var.base_dir,\"**\")")
 staticFilePaths = notImplemented("toset([\nforpinlocal.all_file_paths:p\niflength(p)<length(var.template_file_suffix)||substr(p,length(p)-length(var.template_file_suffix),length(var.template_file_suffix))!=var.template_file_suffix\n])")
 templateFilePaths = { for p in allFilePaths : invoke("std:index:substr", {
   input  = p
-  length = 0
-  offset = length(p) - length(templateFileSuffix)
+  offset = 0
+  length = length(p) - length(templateFileSuffix)
   }).result => p if !invoke("std:index:contains", {
   input   = staticFilePaths
   element = p

--- a/pkg/convert/testdata/programs/registry_module_multiple_versions/pcl/dir_1.0.2/files.pp
+++ b/pkg/convert/testdata/programs/registry_module_multiple_versions/pcl/dir_1.0.2/files.pp
@@ -2,8 +2,8 @@ allFilePaths    = notImplemented("fileset(var.base_dir,\"**\")")
 staticFilePaths = notImplemented("toset([\nforpinlocal.all_file_paths:p\niflength(p)<length(var.template_file_suffix)||substr(p,length(p)-length(var.template_file_suffix),length(var.template_file_suffix))!=var.template_file_suffix\n])")
 templateFilePaths = { for p in allFilePaths : invoke("std:index:substr", {
   input  = p
-  length = 0
-  offset = length(p) - length(templateFileSuffix)
+  offset = 0
+  length = length(p) - length(templateFileSuffix)
   }).result => p if !invoke("std:index:contains", {
   input   = staticFilePaths
   element = p

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -761,7 +761,7 @@ var tfFunctionStd = map[string]struct {
 	},
 	"substr": {
 		token:  "std:index:substr",
-		inputs: []string{"input", "length", "offset"},
+		inputs: []string{"input", "offset", "length"},
 		output: "result",
 	},
 	"sum": {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-converter-terraform/issues/300

Simple fix of the argument order just being recorded the wrong way round. The test files do look a lot more sensible now, e.g.
```
-  length = 0
-  offset = length(p) - length(templateFileSuffix)
+  offset = 0
+  length = length(p) - length(templateFileSuffix)
```