### PR TITLE
Add extra warning to help users of advanced resource lifecycles be aware of differences

### DIFF
--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -2577,7 +2577,7 @@ func convertManagedResources(state *convertState,
 			Severity: hcl.DiagWarning,
 			Summary:  "converting create_before_destroy lifecycle hook is not supported",
 			Detail: `in Pulumi, resources are always created before destroy unless the resource is created with the 
-resource option deleteBeforeReplace, if this behavior is desired, it must be set. 
+resource option deleteBeforeReplace. If this behavior is desired, it must be set. 
 See https://www.pulumi.com/docs/iac/concepts/options/deletebeforereplace/ for details`,
 			Subject: managedResource.DeclRange.Ptr(),
 			Context: managedResource.DeclRange.Ptr(),

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -2576,7 +2576,7 @@ func convertManagedResources(state *convertState,
 		state.appendDiagnostic(&hcl.Diagnostic{
 			Severity: hcl.DiagWarning,
 			Summary:  "converting create_before_destroy lifecycle hook is not supported",
-			Detail: `in pulumi, resources are always created before destroy unless the resource is created with the 
+			Detail: `in Pulumi, resources are always created before destroy unless the resource is created with the 
 resource option deleteBeforeReplace, if this behavior is desired, it must be set. 
 See https://www.pulumi.com/docs/iac/concepts/options/deletebeforereplace/ for details`,
 			Subject: managedResource.DeclRange.Ptr(),

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -2576,8 +2576,11 @@ func convertManagedResources(state *convertState,
 		state.appendDiagnostic(&hcl.Diagnostic{
 			Severity: hcl.DiagWarning,
 			Summary:  "converting create_before_destroy lifecycle hook is not supported",
-			Subject:  managedResource.DeclRange.Ptr(),
-			Context:  managedResource.DeclRange.Ptr(),
+			Detail: `in pulumi, resources are always created before destroy unless the resource is created with the 
+resource option deleteBeforeReplace, if this behavior is desired, it must be set. 
+See https://www.pulumi.com/docs/iac/concepts/options/deletebeforereplace/ for details`,
+			Subject: managedResource.DeclRange.Ptr(),
+			Context: managedResource.DeclRange.Ptr(),
 		})
 	}
 


### PR DESCRIPTION
Pulumi creates resources before destroy by default unlike TF.  There is
a flag to do that in TF, and when it is set, chances are the user may
not be aware pulumi does this, or worse they expect opposite behavior.
Just in case, we emit a warning since they're using lifecycle flags
anyway, and they may wish to know either:

* Why it didn't convert as written
* That their other resources they expect that behaviour need to be
  modified.
