### PR TITLE
Add ability to rename provider configurations for conversions.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,7 @@
 - Implement `regex(all)` through the `pulumi-std` invokes of the same name
 - Implement `toset` through the `pulumi-std` invoke of the same name
 - Implement `cidrsubnets` through the `pulumi-std` invoke of the same name
+- Allow renaming provider configuration names.
 
 ### Bug Fixes
 

--- a/pkg/convert/pulumiverse.go
+++ b/pkg/convert/pulumiverse.go
@@ -51,10 +51,10 @@ var pulumiSupportedProviders = []string{
 	"f5bigip",
 	"fastly",
 	"gandi",
-	"gcp",
 	"github",
 	"github-credentials",
 	"gitlab",
+	"google",
 	"googleworkspace",
 	"harbor",
 	"harness",
@@ -114,4 +114,8 @@ var pulumiSupportedProviders = []string{
 	"wavefront",
 	"xyz",
 	"zitadel",
+}
+
+var pulumiProviderConfigRenames = map[string]string{
+	"google": "gcp",
 }


### PR DESCRIPTION
Previously, we would not rename certain provider configuration keys,
which results in errors after conversion.  This adds a map to add these
cases as we find them, starting with google to GCP.

Fixes pulumi/pulumi-converter-terraform#307
