### PR TITLE
chore: move componentProgramBinderFromAfero to the relevant test file

### DIFF
--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -1532,7 +1532,7 @@ func rewriteTraversal(
 				Severity: hcl.DiagWarning,
 				Summary:  "Converting the builtin variable path.cwd with differing behavior",
 				Detail: `The builtin Terraform variable path.cwd is being converted, but in Pulumi cwd will start at the
-project program directory, not the execution directory`,
+ project program directory, not the execution directory`,
 				Subject: &subjectRange,
 				Context: &contextRange,
 			})

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -1531,8 +1531,8 @@ func rewriteTraversal(
 			state.diagnostics = append(state.diagnostics, &hcl.Diagnostic{
 				Severity: hcl.DiagWarning,
 				Summary:  "Converting the builtin variable path.cwd with differing behavior",
-				Detail: `The builtin Terraform variable path.cwd is being converted, but in Pulumi cwd will start at the
- project program directory, not the execution directory`,
+				Detail: `The builtin Terraform variable path.cwd is being converted, but in Pulumi cwd will start at the ` +
+					"\n" + `project program directory, not the execution directory`,
 				Subject: &subjectRange,
 				Context: &contextRange,
 			})


### PR DESCRIPTION
Looking to debug slow module loading, I noticed `componentProgramBinderFromAfero` function. It is a little challenging to grok as it appears a recursive suspension that is infinite. Appears to only be used in test code though so moving it there.