### PR TITLE
Allow mapper package hint when a provider was not found in the registry

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,6 +23,7 @@
 - Implement `formatlist` through the `pulumi-std` invoke of the same name
 - Fix overlapping dynamic scopes shadowing names, making accessing the shadowed `entry` impossible.
 - Add path.root and path.cwd to the converter to pcl intrinsics projectRoot and cwd respectively.
+- Allow mapper package hint when upstream package was not found
 
 ### Bug Fixes
 

--- a/pkg/convert/info.go
+++ b/pkg/convert/info.go
@@ -68,7 +68,7 @@ func (s *mapperProviderInfoSource) GetProviderInfo(
 	}
 
 	var hint *convert.MapperPackageHint
-	mappingMessage := fmt.Sprintf("could not find mapping information for provider %s;"+
+	mappingMessage := fmt.Sprintf("could not find mapping information for provider %s; "+
 		"try installing a pulumi plugin that supports this terraform provider",
 		tfProvider)
 

--- a/pkg/convert/info.go
+++ b/pkg/convert/info.go
@@ -67,6 +67,9 @@ func (s *mapperProviderInfoSource) GetProviderInfo(
 	}
 
 	var hint *convert.MapperPackageHint
+	mappingMessage := fmt.Sprintf("could not find mapping information for provider %s;"+
+		"try installing a pulumi plugin that supports this terraform provider",
+		tfProvider)
 
 	// If the Pulumi provider name is one that we manage ourselves, we'll use that provider to retrieve information about
 	// mappings from Terraform to Pulumi. If not, then we'll assume that we are going to dynamically bridge a Terraform
@@ -75,6 +78,9 @@ func (s *mapperProviderInfoSource) GetProviderInfo(
 	if isTerraformProvider(pulumiProvider) && requiredProvider != nil {
 		tfVersion, diags := shim.FindTfPackageVersion(requiredProvider)
 		if diags.HasErrors() {
+
+			mappingMessage = fmt.Sprintf("could not find Terraform version for package %s; "+
+				"continuing with the assumption that the specified package exists.", tfProvider)
 			hint = &convert.MapperPackageHint{
 				PluginName: pulumiProvider,
 			}
@@ -110,11 +116,7 @@ func (s *mapperProviderInfoSource) GetProviderInfo(
 
 	// Might be nil or []
 	if len(mapping) == 0 {
-		return nil, fmt.Errorf(
-			"could not find mapping information for provider %s; "+
-				"try installing a pulumi plugin that supports this terraform provider",
-			tfProvider,
-		)
+		return nil, fmt.Errorf(mappingMessage)
 	}
 
 	var info *tfbridge.MarshallableProviderInfo

--- a/pkg/convert/info.go
+++ b/pkg/convert/info.go
@@ -17,6 +17,7 @@ package convert
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -78,7 +79,6 @@ func (s *mapperProviderInfoSource) GetProviderInfo(
 	if isTerraformProvider(pulumiProvider) && requiredProvider != nil {
 		tfVersion, diags := shim.FindTfPackageVersion(requiredProvider)
 		if diags.HasErrors() {
-
 			mappingMessage = fmt.Sprintf("could not find Terraform version for package %s; "+
 				"continuing with the assumption that the specified package exists.", tfProvider)
 			hint = &convert.MapperPackageHint{
@@ -116,7 +116,7 @@ func (s *mapperProviderInfoSource) GetProviderInfo(
 
 	// Might be nil or []
 	if len(mapping) == 0 {
-		return nil, fmt.Errorf(mappingMessage)
+		return nil, errors.New(mappingMessage)
 	}
 
 	var info *tfbridge.MarshallableProviderInfo


### PR DESCRIPTION
This pull request allows for the converter to convert irrespective of whether a real provider was found on the Terraform registry.

This was discovered when running tests in the terraform bridge using a partially mocked provider.
