### PR TITLE
Convert benchmark

### DIFF
--- a/tests/benchmark/.gitignore
+++ b/tests/benchmark/.gitignore
@@ -1,0 +1,1 @@
+**/.terraform

--- a/tests/benchmark/main.go
+++ b/tests/benchmark/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+)
+
+var testCases = []testCase{
+	{
+		name: "random_simple",
+		dir:  "programs/random_simple",
+		assertion: func(output map[string]any) error {
+			if output["name"] == nil {
+				return fmt.Errorf("name is nil")
+			}
+			if len(output["name"].(string)) == 0 {
+				return fmt.Errorf("name is empty")
+			}
+			return nil
+		},
+	},
+}
+
+func formatResults(results map[string]*benchmarkResult) string {
+	buf := bytes.Buffer{}
+	for k, v := range results {
+		buf.WriteString(fmt.Sprintf("%s: %+v\n", k, v))
+	}
+	return buf.String()
+}
+
+func main() {
+	tfResults := runTofuBenchmarks(testCases)
+	fmt.Printf("tfResults: %s", formatResults(tfResults))
+	pulumiResults := runPulumiBenchmarks(testCases)
+	fmt.Printf("pulumiResults: %s", formatResults(pulumiResults))
+}

--- a/tests/benchmark/programs/random_simple/main.tf
+++ b/tests/benchmark/programs/random_simple/main.tf
@@ -1,0 +1,9 @@
+resource "random_string" "bucket_name" {
+  length  = 8
+  special = false
+
+}
+
+output "name" {
+  value = random_string.bucket_name.result
+}

--- a/tests/benchmark/pul.go
+++ b/tests/benchmark/pul.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+)
+
+func runPulumi(dir string, args ...string) ([]byte, error) {
+	return run(dir, append([]string{"pulumi"}, args...)...)
+}
+
+func runPulumiConvert(srcDir string, outDir string) error {
+	_, err := runPulumi(srcDir, "convert", "--from", "terraform", "--language", "typescript", "--out", outDir)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func runPulumiPlan(dir string) error {
+	_, err := runPulumi(dir, "stack", "init", "test")
+	if err != nil {
+		return err
+	}
+	_, err = runPulumi(dir, "preview", "--stack", "test")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func runPulumiApply(dir string) (map[string]any, error) {
+	defer runPulumi(dir, "stack", "rm", "--force", "--stack", "test", "--yes")
+	defer runPulumi(dir, "destroy", "--yes", "--stack", "test")
+	_, err := runPulumi(dir, "up", "--yes", "--stack", "test")
+	if err != nil {
+		return nil, err
+	}
+
+	output := map[string]any{}
+	stdout, err := runPulumi(dir, "stack", "output", "-json", "--stack", "test")
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(stdout, &output)
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+func runPulumiBenchmarks(testCases []testCase) map[string]*benchmarkResult {
+	results := map[string]*benchmarkResult{}
+	for _, tc := range testCases {
+		results[tc.name] = &benchmarkResult{}
+		dir, err := os.MkdirTemp("", "pulumi-benchmark")
+		if err != nil {
+			log.Fatal(err)
+		}
+		err = os.CopyFS(dir, os.DirFS(tc.dir))
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		{
+			err = runPulumiConvert(tc.dir, dir)
+			if err != nil {
+				log.Printf("convert failed: %v", err)
+				continue
+			}
+			results[tc.name].convertSuccess = true
+		}
+
+		{
+			err = runPulumiPlan(dir)
+			if err != nil {
+				log.Printf("plan failed: %v", err)
+				continue
+			}
+			results[tc.name].planSuccess = true
+		}
+
+		output := map[string]any{}
+
+		{
+			output, err = runPulumiApply(dir)
+			if err != nil {
+				log.Printf("apply failed: %v", err)
+				continue
+			}
+			results[tc.name].applySuccess = true
+		}
+
+		{
+			err = tc.assertion(output)
+			if err != nil {
+				log.Printf("assertion failed: %v", err)
+				continue
+			}
+			results[tc.name].assertSuccess = true
+		}
+	}
+	return results
+}

--- a/tests/benchmark/run.go
+++ b/tests/benchmark/run.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"os/exec"
+)
+
+func run(dir string, args ...string) ([]byte, error) {
+	stdoutBuf := bytes.Buffer{}
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = os.Stderr
+	cmd.Dir = dir
+	err := cmd.Run()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			log.Printf("stderr: %s", string(exitErr.Stderr))
+		}
+		return nil, err
+	}
+	return stdoutBuf.Bytes(), nil
+}

--- a/tests/benchmark/tofu.go
+++ b/tests/benchmark/tofu.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+)
+
+func runTofu(dir string, args ...string) ([]byte, error) {
+	return run(dir, append([]string{"tofu"}, args...)...)
+}
+
+type tfOutput struct {
+	Value any `json:"value"`
+}
+
+func runTofuPlan(dir string) error {
+	_, err := runTofu(dir, "init")
+	if err != nil {
+		return err
+	}
+	_, err = runTofu(dir, "plan")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func runTofuApply(dir string) (map[string]any, error) {
+	defer runTofu(dir, "destroy", "-auto-approve")
+	_, err := runTofu(dir, "apply", "-auto-approve")
+	if err != nil {
+		return nil, err
+	}
+
+	tfOutput := map[string]tfOutput{}
+	stdout, err := runTofu(dir, "output", "-json")
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(stdout, &tfOutput)
+	if err != nil {
+		return nil, err
+	}
+
+	output := map[string]any{}
+	for k, v := range tfOutput {
+		output[k] = v.Value
+	}
+	return output, nil
+}
+
+type testCase struct {
+	name      string
+	dir       string
+	assertion func(output map[string]any) error
+}
+
+type benchmarkResult struct {
+	convertSuccess bool
+	planSuccess    bool
+	applySuccess   bool
+	assertSuccess  bool
+}
+
+func runTofuBenchmarks(testCases []testCase) map[string]*benchmarkResult {
+	results := map[string]*benchmarkResult{}
+	for _, tc := range testCases {
+		results[tc.name] = &benchmarkResult{}
+		dir, err := os.MkdirTemp("", "tofu-benchmark")
+		if err != nil {
+			log.Fatal(err)
+		}
+		err = os.CopyFS(dir, os.DirFS(tc.dir))
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		results[tc.name].convertSuccess = true
+
+		{
+			err = runTofuPlan(dir)
+			if err != nil {
+				log.Printf("plan failed: %v", err)
+				continue
+			}
+			results[tc.name].planSuccess = true
+		}
+
+		output := map[string]any{}
+
+		{
+			output, err = runTofuApply(dir)
+			if err != nil {
+				log.Printf("apply failed: %v", err)
+				continue
+			}
+			results[tc.name].applySuccess = true
+		}
+
+		{
+			err = tc.assertion(output)
+			if err != nil {
+				log.Printf("assertion failed: %v", err)
+				continue
+			}
+			results[tc.name].assertSuccess = true
+		}
+	}
+	return results
+}


### PR DESCRIPTION
Adds some code for running a TF conversion benchmark. The plan is to:

1. Get a collection of TF programs and verify that `tofu plan`, and `tofu apply` work fine, as well as some program-specific assertion (ex. my bucket is configured correctly, etc.)
2. Run `pulumi convert` on that set of programs and verify that `pulumi preview` and `pulumi up` work fine, as well as the specific assertion from above.
3. Run the same via some LLM convert and see what the results are.

The first two are present here as well as a simple program based on the `random` provider.