### PR TITLE
Don't copy TF files to the output directory

### DIFF
--- a/tests/benchmark/pul.go
+++ b/tests/benchmark/pul.go
@@ -21,8 +21,8 @@ func runPulumiConvert(srcDir string, outDir string) error {
 
 func runClaudeConvert(srcDir string, outDir string) error {
 	// This prompt is intentionally simplistic for now. We'll evolve it with larger test cases.
-	prompt := "Convert this Terraform project to Pulumi TypeScript. Emit a full Pulumi project including package.json, tsconfig.json, and Pulumi.yaml."
-	stdout, err := run(outDir, "claude", "-p", prompt, "--dangerously-skip-permissions")
+	prompt := fmt.Sprintf("Convert this Terraform project to Pulumi TypeScript. Emit a full Pulumi project including package.json, tsconfig.json, and Pulumi.yaml. Place the project files in %s.", outDir)
+	stdout, err := run(srcDir, "claude", "-p", prompt, "--add-dir", outDir, "--dangerously-skip-permissions")
 	fmt.Printf("Claude convert stdout: %s\n", stdout)
 	if err != nil {
 		return err
@@ -87,7 +87,7 @@ func runPulumiBenchmarks(testCases []testCase, runPulumiConvert func(srcDir, out
 			log.Fatal(err)
 		}
 		log.Printf("dir: %s", dir)
-		err = os.CopyFS(dir, os.DirFS(tc.dir))
+		err = copyDirExcept(tc.dir, dir, ".tf")
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/tests/benchmark/util.go
+++ b/tests/benchmark/util.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func copyDirExcept(src, dest, excludeSuffix string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Create a relative path
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		destPath := filepath.Join(dest, relPath)
+
+		if info.IsDir() {
+			return os.MkdirAll(destPath, info.Mode())
+		}
+
+		if strings.HasSuffix(info.Name(), excludeSuffix) {
+			return nil
+		}
+
+		srcFile, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer srcFile.Close()
+
+		destFile, err := os.Create(destPath)
+		if err != nil {
+			return err
+		}
+		defer destFile.Close()
+
+		_, err = io.Copy(destFile, srcFile)
+		return err
+	})
+}


### PR DESCRIPTION
It seems to be cleared not to copy TF files into the Pulumi output directory. All the other files are still copied by default because they may be required for a successful deployment.

Surprisingly, I couldn't find a standard function to do that, so I drafted my own.

Also, adjusted the Claude's prompt and input arguments to make sure it reads files from the source directory but writes to the output one. The tests passed for me locally.