### PR TITLE
Add AWS lambda example to conversion benchmark

### DIFF
--- a/tests/benchmark/.gitignore
+++ b/tests/benchmark/.gitignore
@@ -1,1 +1,5 @@
 **/.terraform
+**/.terraform.lock.hcl
+**/terraform.tfstate
+**/terraform.tfstate.backup
+**/hello-world.zip

--- a/tests/benchmark/main.go
+++ b/tests/benchmark/main.go
@@ -4,45 +4,11 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"time"
 )
-
-var testCases = []testCase{
-	{
-		name: "random_simple",
-		dir:  "programs/random_simple",
-		assertion: func(output map[string]any) error {
-			if output["name"] == nil {
-				return fmt.Errorf("name is nil")
-			}
-			if len(output["name"].(string)) == 0 {
-				return fmt.Errorf("name is empty")
-			}
-			return nil
-		},
-	},
-	{
-		name: "aws_bucket",
-		dir:  "programs/aws_bucket",
-		assertion: func(output map[string]any) error {
-			if output["url"] == nil {
-				return fmt.Errorf("url is nil")
-			}
-			if len(output["url"].(string)) == 0 {
-				return fmt.Errorf("url is empty")
-			}
-			out, err := run(".", "aws", "s3", "cp", output["url"].(string), "-")
-			if err != nil {
-				return fmt.Errorf("failed to copy object: %w", err)
-			}
-			if string(out) != "hi" {
-				return fmt.Errorf("expected 'hi', got %s", string(out))
-			}
-
-			return nil
-		},
-	},
-}
 
 func formatResults(results map[string]*benchmarkResult) string {
 	buf := bytes.Buffer{}
@@ -84,17 +50,22 @@ func resultSummary(results map[string]*benchmarkResult) string {
 	return buf.String()
 }
 
-func runBenchmarkForLanguage(language string) {
+func runBenchmarkForLanguage(language string, skipTF bool, testCases []testCase) {
 	switch language {
 	case "typescript":
-		tfResults := runTofuBenchmarks(testCases)
-		fmt.Printf("tfResults:\n%s", formatResults(tfResults))
+		tfResults := map[string]*benchmarkResult{}
+		if !skipTF {
+			tfResults = runTofuBenchmarks(testCases)
+			fmt.Printf("tfResults:\n%s", formatResults(tfResults))
+		}
 		claudeResults := runPulumiBenchmarks(testCases, runClaudeConvert)
 		fmt.Printf("claudeResults:\n%s", formatResults(claudeResults))
 		pulumiResultsTs := runPulumiBenchmarks(testCases, runPulumiConvertTS)
 		fmt.Printf("pulumiResultsTs:\n%s", formatResults(pulumiResultsTs))
 		fmt.Println("--------------------------------")
-		fmt.Printf("tfResults:\n%s", resultSummary(tfResults))
+		if !skipTF {
+			fmt.Printf("tfResults:\n%s", resultSummary(tfResults))
+		}
 		fmt.Printf("claudeResults:\n%s", resultSummary(claudeResults))
 		fmt.Printf("pulumiResultsTs:\n%s", resultSummary(pulumiResultsTs))
 	default:
@@ -104,9 +75,13 @@ func runBenchmarkForLanguage(language string) {
 	}
 }
 
-func runBenchmark() {
-	tfResults := runTofuBenchmarks(testCases)
-	fmt.Printf("tfResults:\n%s", formatResults(tfResults))
+func runBenchmark(skipTF bool, testCases []testCase) {
+	tfResults := map[string]*benchmarkResult{}
+	if !skipTF {
+		tfResults = runTofuBenchmarks(testCases)
+		fmt.Printf("tfResults:\n%s", formatResults(tfResults))
+	}
+
 	claudeResults := runPulumiBenchmarks(testCases, runClaudeConvert)
 	fmt.Printf("claudeResults:\n%s", formatResults(claudeResults))
 	pulumiResultsTs := runPulumiBenchmarks(testCases, runPulumiConvertTS)
@@ -122,7 +97,9 @@ func runBenchmark() {
 	pulumiResultsYaml := runPulumiBenchmarks(testCases, runPulumiConvertYaml)
 	fmt.Printf("pulumiResultsYaml:\n%s", formatResults(pulumiResultsYaml))
 	fmt.Println("--------------------------------")
-	fmt.Printf("tfResults:\n%s", resultSummary(tfResults))
+	if !skipTF {
+		fmt.Printf("tfResults:\n%s", resultSummary(tfResults))
+	}
 	fmt.Printf("claudeResults:\n%s", resultSummary(claudeResults))
 	fmt.Printf("pulumiResultsTs:\n%s", resultSummary(pulumiResultsTs))
 	fmt.Printf("pulumiResultsPy:\n%s", resultSummary(pulumiResultsPy))
@@ -132,12 +109,105 @@ func runBenchmark() {
 	fmt.Printf("pulumiResultsYaml:\n%s", resultSummary(pulumiResultsYaml))
 }
 
+var allTestCases = map[string]testCase{
+	"random_simple": {
+		name: "random_simple",
+		dir:  "programs/random_simple",
+		assertion: func(output map[string]any) error {
+			if output["name"] == nil {
+				return fmt.Errorf("name is nil")
+			}
+			if len(output["name"].(string)) == 0 {
+				return fmt.Errorf("name is empty")
+			}
+			return nil
+		},
+	},
+	"aws_bucket": {
+		name: "aws_bucket",
+		dir:  "programs/aws_bucket",
+		assertion: func(output map[string]any) error {
+			if output["url"] == nil {
+				return fmt.Errorf("url is nil")
+			}
+			if len(output["url"].(string)) == 0 {
+				return fmt.Errorf("url is empty")
+			}
+			out, err := run(".", "aws", "s3", "cp", output["url"].(string), "-")
+			if err != nil {
+				return fmt.Errorf("failed to copy object: %w", err)
+			}
+			if string(out) != "hi" {
+				return fmt.Errorf("expected 'hi', got %s", string(out))
+			}
+
+			return nil
+		},
+	},
+	"aws_lambda_api": {
+		name: "aws_lambda_api",
+		dir:  "programs/aws_lambda_api",
+		assertion: func(output map[string]any) error {
+			time.Sleep(2 * time.Second)
+
+			if output["url"] == nil {
+				return fmt.Errorf("url is nil")
+			}
+
+			url := output["url"].(string)
+			if len(url) == 0 {
+				return fmt.Errorf("url is empty")
+			}
+
+			// make an http request to the url
+			resp, err := http.Get(url + "/hello?Name=John")
+			if err != nil {
+				return fmt.Errorf("failed to make http request: %w", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != 200 {
+				return fmt.Errorf("expected status code 200, got %d", resp.StatusCode)
+			}
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			expected := `{"message":"Hello, John!"}`
+			if string(body) != expected {
+				return fmt.Errorf("expected %s, got %s", expected, string(body))
+			}
+
+			return nil
+		},
+	},
+}
+
 func main() {
 	language := flag.String("language", "typescript", "The language to benchmark. all will run all languages")
+	skipTF := flag.Bool("skip-tf", false, "Skip the Terraform benchmark")
+	example := flag.String("example", "all", "The example to run. all will run all examples")
 	flag.Parse()
-	if *language == "all" {
-		runBenchmark()
+
+	testCases := []testCase{}
+	if *example == "all" {
+		for _, v := range allTestCases {
+			testCases = append(testCases, v)
+		}
 	} else {
-		runBenchmarkForLanguage(*language)
+		tCase, ok := allTestCases[*example]
+		if !ok {
+			fmt.Printf("Example %s not found\n", *example)
+			os.Exit(1)
+		}
+		testCases = []testCase{tCase}
+	}
+
+	if *language == "all" {
+		runBenchmark(*skipTF, testCases)
+	} else {
+		runBenchmarkForLanguage(*language, *skipTF, testCases)
 	}
 }

--- a/tests/benchmark/programs/aws_lambda_api/api_gateway.tf
+++ b/tests/benchmark/programs/aws_lambda_api/api_gateway.tf
@@ -1,0 +1,59 @@
+resource "aws_apigatewayv2_api" "lambda" {
+  name          = "serverless_lambda_gw"
+  protocol_type = "HTTP"
+}
+
+resource "aws_apigatewayv2_stage" "lambda" {
+  api_id = aws_apigatewayv2_api.lambda.id
+
+  name        = "serverless_lambda_stage"
+  auto_deploy = true
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.api_gw.arn
+
+    format = jsonencode({
+      requestId               = "$context.requestId"
+      sourceIp                = "$context.identity.sourceIp"
+      requestTime             = "$context.requestTime"
+      protocol                = "$context.protocol"
+      httpMethod              = "$context.httpMethod"
+      resourcePath            = "$context.resourcePath"
+      routeKey                = "$context.routeKey"
+      status                  = "$context.status"
+      responseLength          = "$context.responseLength"
+      integrationErrorMessage = "$context.integrationErrorMessage"
+      }
+    )
+  }
+}
+
+resource "aws_apigatewayv2_integration" "hello_world" {
+  api_id = aws_apigatewayv2_api.lambda.id
+
+  integration_uri    = aws_lambda_function.hello_world.invoke_arn
+  integration_type   = "AWS_PROXY"
+  integration_method = "POST"
+}
+
+resource "aws_apigatewayv2_route" "hello_world" {
+  api_id = aws_apigatewayv2_api.lambda.id
+
+  route_key = "GET /hello"
+  target    = "integrations/${aws_apigatewayv2_integration.hello_world.id}"
+}
+
+resource "aws_cloudwatch_log_group" "api_gw" {
+  name = "/aws/api_gw/${aws_apigatewayv2_api.lambda.name}"
+
+  retention_in_days = 30
+}
+
+resource "aws_lambda_permission" "api_gw" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.hello_world.function_name
+  principal     = "apigateway.amazonaws.com"
+
+  source_arn = "${aws_apigatewayv2_api.lambda.execution_arn}/*/*"
+}

--- a/tests/benchmark/programs/aws_lambda_api/api_gateway.tf
+++ b/tests/benchmark/programs/aws_lambda_api/api_gateway.tf
@@ -1,5 +1,11 @@
+resource "random_string" "api_gw_name" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "aws_apigatewayv2_api" "lambda" {
-  name          = "serverless_lambda_gw"
+  name          = "serverless_lambda_gw-${random_string.api_gw_name.result}"
   protocol_type = "HTTP"
 }
 

--- a/tests/benchmark/programs/aws_lambda_api/hello-world/hello.js
+++ b/tests/benchmark/programs/aws_lambda_api/hello-world/hello.js
@@ -1,0 +1,18 @@
+module.exports.handler = async (event) => {
+    console.log('Event: ', event)
+    let responseMessage = 'Hello, World!';
+  
+    if (event.queryStringParameters && event.queryStringParameters['Name']) {
+      responseMessage = 'Hello, ' + event.queryStringParameters['Name'] + '!';
+    }
+  
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        message: responseMessage,
+      }),
+    }
+  }

--- a/tests/benchmark/programs/aws_lambda_api/main.tf
+++ b/tests/benchmark/programs/aws_lambda_api/main.tf
@@ -56,8 +56,14 @@ resource "aws_s3_object" "lambda_hello_world" {
   etag = filemd5(data.archive_file.lambda_hello_world.output_path)
 }
 
+resource "random_string" "lambda_name" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "aws_lambda_function" "hello_world" {
-  function_name = "HelloWorld"
+  function_name = "HelloWorld-${random_string.lambda_name.result}"
 
   s3_bucket = aws_s3_bucket.lambda_bucket.id
   s3_key    = aws_s3_object.lambda_hello_world.key

--- a/tests/benchmark/programs/aws_lambda_api/main.tf
+++ b/tests/benchmark/programs/aws_lambda_api/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    archive = {
+      source = "hashicorp/archive"
+    }
+  }
+}
+
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "random_pet" "lambda_bucket_name" {
+  prefix = "learn-terraform-functions"
+  length = 4
+}
+
+resource "aws_s3_bucket" "lambda_bucket" {
+  bucket = random_pet.lambda_bucket_name.id
+}
+
+resource "aws_s3_bucket_ownership_controls" "lambda_bucket" {
+  bucket = aws_s3_bucket.lambda_bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "lambda_bucket" {
+  depends_on = [aws_s3_bucket_ownership_controls.lambda_bucket]
+
+  bucket = aws_s3_bucket.lambda_bucket.id
+  acl    = "private"
+}
+
+data "archive_file" "lambda_hello_world" {
+  type = "zip"
+
+  source_dir  = "${path.root}/hello-world"
+  output_path = "${path.root}/hello-world.zip"
+}
+
+resource "aws_s3_object" "lambda_hello_world" {
+  bucket = aws_s3_bucket.lambda_bucket.id
+
+  key    = "hello-world.zip"
+  source = data.archive_file.lambda_hello_world.output_path
+
+  etag = filemd5(data.archive_file.lambda_hello_world.output_path)
+}
+
+resource "aws_lambda_function" "hello_world" {
+  function_name = "HelloWorld"
+
+  s3_bucket = aws_s3_bucket.lambda_bucket.id
+  s3_key    = aws_s3_object.lambda_hello_world.key
+
+  runtime = "nodejs20.x"
+  handler = "hello.handler"
+
+  source_code_hash = data.archive_file.lambda_hello_world.output_base64sha256
+
+  role = aws_iam_role.lambda_exec.arn
+}
+
+
+resource "aws_cloudwatch_log_group" "hello_world" {
+  name = "/aws/lambda/${aws_lambda_function.hello_world.function_name}"
+
+  retention_in_days = 3
+}

--- a/tests/benchmark/programs/aws_lambda_api/outputs.tf
+++ b/tests/benchmark/programs/aws_lambda_api/outputs.tf
@@ -1,0 +1,5 @@
+output "url" {
+  description = "Base URL for API Gateway stage."
+
+  value = aws_apigatewayv2_stage.lambda.invoke_url
+}

--- a/tests/benchmark/programs/aws_lambda_api/permissions.tf
+++ b/tests/benchmark/programs/aws_lambda_api/permissions.tf
@@ -1,5 +1,11 @@
+resource "random_string" "lambda_role_name" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 resource "aws_iam_role" "lambda_exec" {
-  name = "serverless_lambda"
+  name = "serverless_lambda_${random_string.lambda_role_name.result}"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/tests/benchmark/programs/aws_lambda_api/permissions.tf
+++ b/tests/benchmark/programs/aws_lambda_api/permissions.tf
@@ -1,0 +1,21 @@
+resource "aws_iam_role" "lambda_exec" {
+  name = "serverless_lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Sid    = ""
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_policy" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}


### PR DESCRIPTION
This adds a non-trivial AWS lambda example to the conversion benchmark. Adapted from https://developer.hashicorp.com/terraform/tutorials/aws/lambda-api-gateway