### PR TITLE
Add a bucket with tags example to conversion benchmark

### DIFF
--- a/tests/benchmark/programs/aws_bucket_with_tags/main.tf
+++ b/tests/benchmark/programs/aws_bucket_with_tags/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+
+  default_tags {
+    tags = {
+      my_tag = "my_value"
+    }
+  }
+}
+
+resource "random_string" "bucket_name" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+resource "aws_s3_bucket" "example" {
+  bucket = random_string.bucket_name.result
+  tags = {
+    Name = "My bucket"
+  }
+}
+
+output "name" {
+  value = aws_s3_bucket.example.bucket
+}


### PR DESCRIPTION
Noticed that both the converter and the LLM struggle with provider config in some situations. The converter does not implement blocks in provider config and the LLM sometimes tries to generate some invalid YAML based on the provider config.

This PR adds a simple example to test that.