### PR TITLE
Benchmark allow multiple assertions per example

### DIFF
--- a/tests/benchmark/main.go
+++ b/tests/benchmark/main.go
@@ -43,8 +43,8 @@ func resultSummary(results map[string]*benchmarkResult) string {
 			if assertSuccess {
 				res.assertSuccesses++
 			}
-			res.assertTotal++
 		}
+		res.assertTotal += len(v.assertSuccesses)
 	}
 	buf.WriteString(fmt.Sprintf("total: %d\n", total))
 	buf.WriteString(fmt.Sprintf("convertSuccesses: %d (%d%%)\n", res.convertSuccesses, res.convertSuccesses*100/total))
@@ -117,8 +117,8 @@ var allTestCases = map[string]testCase{
 	"random_simple": {
 		name: "random_simple",
 		dir:  "programs/random_simple",
-		assertions: []assertion{
-			func(output map[string]any) error {
+		assertions: map[string]assertion{
+			"name is not empty": func(output map[string]any) error {
 				if output["name"] == nil {
 					return fmt.Errorf("name is nil")
 				}
@@ -132,8 +132,8 @@ var allTestCases = map[string]testCase{
 	"aws_bucket": {
 		name: "aws_bucket",
 		dir:  "programs/aws_bucket",
-		assertions: []assertion{
-			func(output map[string]any) error {
+		assertions: map[string]assertion{
+			"s3 object content is correct": func(output map[string]any) error {
 				if output["url"] == nil {
 					return fmt.Errorf("url is nil")
 				}
@@ -155,8 +155,8 @@ var allTestCases = map[string]testCase{
 	"aws_lambda_api": {
 		name: "aws_lambda_api",
 		dir:  "programs/aws_lambda_api",
-		assertions: []assertion{
-			func(output map[string]any) error {
+		assertions: map[string]assertion{
+			"lambda api response is correct": func(output map[string]any) error {
 				time.Sleep(2 * time.Second)
 
 				if output["url"] == nil {

--- a/tests/benchmark/main.go
+++ b/tests/benchmark/main.go
@@ -26,6 +26,7 @@ func resultSummary(results map[string]*benchmarkResult) string {
 		planSuccesses    int
 		applySuccesses   int
 		assertSuccesses  int
+		assertTotal      int
 	}
 	res := summary{}
 	for _, v := range results {
@@ -38,15 +39,18 @@ func resultSummary(results map[string]*benchmarkResult) string {
 		if v.applySuccess {
 			res.applySuccesses++
 		}
-		if v.assertSuccess {
-			res.assertSuccesses++
+		for _, assertSuccess := range v.assertSuccesses {
+			if assertSuccess {
+				res.assertSuccesses++
+			}
+			res.assertTotal++
 		}
 	}
 	buf.WriteString(fmt.Sprintf("total: %d\n", total))
 	buf.WriteString(fmt.Sprintf("convertSuccesses: %d (%d%%)\n", res.convertSuccesses, res.convertSuccesses*100/total))
 	buf.WriteString(fmt.Sprintf("planSuccesses: %d (%d%%)\n", res.planSuccesses, res.planSuccesses*100/total))
 	buf.WriteString(fmt.Sprintf("applySuccesses: %d (%d%%)\n", res.applySuccesses, res.applySuccesses*100/total))
-	buf.WriteString(fmt.Sprintf("assertSuccesses: %d (%d%%)\n", res.assertSuccesses, res.assertSuccesses*100/total))
+	buf.WriteString(fmt.Sprintf("assertSuccesses: %d (%d%%)\n", res.assertSuccesses, res.assertSuccesses*100/res.assertTotal))
 	return buf.String()
 }
 
@@ -113,74 +117,80 @@ var allTestCases = map[string]testCase{
 	"random_simple": {
 		name: "random_simple",
 		dir:  "programs/random_simple",
-		assertion: func(output map[string]any) error {
-			if output["name"] == nil {
-				return fmt.Errorf("name is nil")
-			}
-			if len(output["name"].(string)) == 0 {
-				return fmt.Errorf("name is empty")
-			}
-			return nil
+		assertions: []assertion{
+			func(output map[string]any) error {
+				if output["name"] == nil {
+					return fmt.Errorf("name is nil")
+				}
+				if len(output["name"].(string)) == 0 {
+					return fmt.Errorf("name is empty")
+				}
+				return nil
+			},
 		},
 	},
 	"aws_bucket": {
 		name: "aws_bucket",
 		dir:  "programs/aws_bucket",
-		assertion: func(output map[string]any) error {
-			if output["url"] == nil {
-				return fmt.Errorf("url is nil")
-			}
-			if len(output["url"].(string)) == 0 {
-				return fmt.Errorf("url is empty")
-			}
-			out, err := run(".", "aws", "s3", "cp", output["url"].(string), "-")
-			if err != nil {
-				return fmt.Errorf("failed to copy object: %w", err)
-			}
-			if string(out) != "hi" {
-				return fmt.Errorf("expected 'hi', got %s", string(out))
-			}
+		assertions: []assertion{
+			func(output map[string]any) error {
+				if output["url"] == nil {
+					return fmt.Errorf("url is nil")
+				}
+				if len(output["url"].(string)) == 0 {
+					return fmt.Errorf("url is empty")
+				}
+				out, err := run(".", "aws", "s3", "cp", output["url"].(string), "-")
+				if err != nil {
+					return fmt.Errorf("failed to copy object: %w", err)
+				}
+				if string(out) != "hi" {
+					return fmt.Errorf("expected 'hi', got %s", string(out))
+				}
 
-			return nil
+				return nil
+			},
 		},
 	},
 	"aws_lambda_api": {
 		name: "aws_lambda_api",
 		dir:  "programs/aws_lambda_api",
-		assertion: func(output map[string]any) error {
-			time.Sleep(2 * time.Second)
+		assertions: []assertion{
+			func(output map[string]any) error {
+				time.Sleep(2 * time.Second)
 
-			if output["url"] == nil {
-				return fmt.Errorf("url is nil")
-			}
+				if output["url"] == nil {
+					return fmt.Errorf("url is nil")
+				}
 
-			url := output["url"].(string)
-			if len(url) == 0 {
-				return fmt.Errorf("url is empty")
-			}
+				url := output["url"].(string)
+				if len(url) == 0 {
+					return fmt.Errorf("url is empty")
+				}
 
-			// make an http request to the url
-			resp, err := http.Get(url + "/hello?Name=John")
-			if err != nil {
-				return fmt.Errorf("failed to make http request: %w", err)
-			}
-			defer resp.Body.Close()
+				// make an http request to the url
+				resp, err := http.Get(url + "/hello?Name=John")
+				if err != nil {
+					return fmt.Errorf("failed to make http request: %w", err)
+				}
+				defer resp.Body.Close()
 
-			if resp.StatusCode != 200 {
-				return fmt.Errorf("expected status code 200, got %d", resp.StatusCode)
-			}
+				if resp.StatusCode != 200 {
+					return fmt.Errorf("expected status code 200, got %d", resp.StatusCode)
+				}
 
-			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return fmt.Errorf("failed to read response body: %w", err)
-			}
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return fmt.Errorf("failed to read response body: %w", err)
+				}
 
-			expected := `{"message":"Hello, John!"}`
-			if string(body) != expected {
-				return fmt.Errorf("expected %s, got %s", expected, string(body))
-			}
+				expected := `{"message":"Hello, John!"}`
+				if string(body) != expected {
+					return fmt.Errorf("expected %s, got %s", expected, string(body))
+				}
 
-			return nil
+				return nil
+			},
 		},
 	},
 }

--- a/tests/benchmark/pul.go
+++ b/tests/benchmark/pul.go
@@ -142,7 +142,13 @@ func runPulumiDestroy(dir string) error {
 func runPulumiBenchmarks(testCases []testCase, convertFunc func(srcDir, outDir string) error) map[string]*benchmarkResult {
 	results := map[string]*benchmarkResult{}
 	for _, tc := range testCases {
-		results[tc.name] = &benchmarkResult{}
+		results[tc.name] = &benchmarkResult{
+			assertSuccesses: map[string]bool{},
+		}
+		for k := range tc.assertions {
+			results[tc.name].assertSuccesses[k] = false
+		}
+
 		dir, err := os.MkdirTemp("", "pulumi-benchmark")
 		if err != nil {
 			log.Fatal(err)
@@ -184,13 +190,13 @@ func runPulumiBenchmarks(testCases []testCase, convertFunc func(srcDir, outDir s
 		}
 
 		{
-			for _, assertion := range tc.assertions {
+			for k, assertion := range tc.assertions {
 				err = assertion(output)
 				if err != nil {
-					results[tc.name].assertSuccesses = append(results[tc.name].assertSuccesses, false)
+					results[tc.name].assertSuccesses[k] = false
 					continue
 				}
-				results[tc.name].assertSuccesses = append(results[tc.name].assertSuccesses, true)
+				results[tc.name].assertSuccesses[k] = true
 			}
 		}
 	}

--- a/tests/benchmark/pul.go
+++ b/tests/benchmark/pul.go
@@ -184,12 +184,14 @@ func runPulumiBenchmarks(testCases []testCase, convertFunc func(srcDir, outDir s
 		}
 
 		{
-			err = tc.assertion(output)
-			if err != nil {
-				log.Printf("assertion failed: %v", err)
-				continue
+			for _, assertion := range tc.assertions {
+				err = assertion(output)
+				if err != nil {
+					results[tc.name].assertSuccesses = append(results[tc.name].assertSuccesses, false)
+					continue
+				}
+				results[tc.name].assertSuccesses = append(results[tc.name].assertSuccesses, true)
 			}
-			results[tc.name].assertSuccess = true
 		}
 	}
 	return results


### PR DESCRIPTION
This adds the ability to have multiple separate assertions per example, so they don't all fail or succeed together. This will allow us to test multiple things per example and enable more complex programs.