### PR TITLE
Benchmark add tags to all examples

### DIFF
--- a/tests/benchmark/programs/aws_bucket/main.tf
+++ b/tests/benchmark/programs/aws_bucket/main.tf
@@ -4,6 +4,16 @@ resource "random_string" "bucket_name" {
   upper   = false
 }
 
+provider "aws" {
+  region = "us-east-1"
+
+  default_tags {
+    tags = {
+      "my_tag" = "my_value"
+    }
+  }
+}
+
 resource "aws_s3_bucket" "example" {
   bucket = random_string.bucket_name.result
   tags = {
@@ -19,4 +29,8 @@ resource "aws_s3_bucket_object" "object" {
 
 output "url" {
   value = "s3://${aws_s3_bucket.example.bucket}/${aws_s3_bucket_object.object.key}"
+}
+
+output "name" {
+  value = aws_s3_bucket.example.bucket
 }

--- a/tests/benchmark/programs/aws_lambda_api/main.tf
+++ b/tests/benchmark/programs/aws_lambda_api/main.tf
@@ -15,6 +15,13 @@ terraform {
 
 provider "aws" {
   region = "us-east-1"
+
+  default_tags {
+    tags = {
+      "project"     = "aws_lambda_api"
+      "environment" = "test"
+    }
+  }
 }
 
 resource "random_pet" "lambda_bucket_name" {
@@ -74,6 +81,10 @@ resource "aws_lambda_function" "hello_world" {
   source_code_hash = data.archive_file.lambda_hello_world.output_base64sha256
 
   role = aws_iam_role.lambda_exec.arn
+
+  tags = {
+    "my_tag" = "my_value"
+  }
 }
 
 

--- a/tests/benchmark/programs/aws_lambda_api/outputs.tf
+++ b/tests/benchmark/programs/aws_lambda_api/outputs.tf
@@ -3,3 +3,7 @@ output "url" {
 
   value = aws_apigatewayv2_stage.lambda.invoke_url
 }
+
+output "arn" {
+  value = aws_lambda_function.hello_world.arn
+}


### PR DESCRIPTION
This PR adds AWS tags to the bucket and lambda examples. Suggestion from https://github.com/pulumi/pulumi-converter-terraform/pull/341#issuecomment-2997674201

Results:

```
aws_lambda_api:
--------------------------------
tfResults:
total: 1
convertSuccesses: 1 (100%)
planSuccesses: 1 (100%)
applySuccesses: 1 (100%)
assertSuccesses: 2 (100%)
claudeResults:
total: 1
convertSuccesses: 0 (0%)
planSuccesses: 0 (0%)
applySuccesses: 0 (0%)
assertSuccesses: 0 (0%)
pulumiResultsTs:
total: 1
convertSuccesses: 1 (100%)
planSuccesses: 1 (100%)
applySuccesses: 1 (100%)
assertSuccesses: 1 (50%)


aws_bucket:
--------------------------------
tfResults:
total: 1
convertSuccesses: 1 (100%)
planSuccesses: 1 (100%)
applySuccesses: 1 (100%)
assertSuccesses: 2 (100%)
claudeResults:
total: 1
convertSuccesses: 1 (100%)
planSuccesses: 1 (100%)
applySuccesses: 1 (100%)
assertSuccesses: 2 (100%)
pulumiResultsTs:
total: 1
convertSuccesses: 1 (100%)
planSuccesses: 1 (100%)
applySuccesses: 1 (100%)
assertSuccesses: 1 (50%)
```