### PR TITLE
Remove pulumi-sumologic from list of pulumi-supported providers

### DIFF
--- a/pkg/convert/pulumiverse.go
+++ b/pkg/convert/pulumiverse.go
@@ -118,7 +118,6 @@ var pulumiSupportedProviders = []string{
 	"splunk",
 	"spotinst",
 	"statuscake",
-	"sumologic",
 	"tailscale",
 	"tf-provider-boilerplate",
 	"time",


### PR DESCRIPTION
We are [deprecating pulumi-sumologic](https://github.com/pulumi/pulumi-sumologic/issues/653). 
We should remove it from the supported list so that conversions can occur via downloading the latest onelogin upstream from opentofu.
