### PR TITLE
add VPC benchmark example

### DIFF
--- a/tests/benchmark/main.go
+++ b/tests/benchmark/main.go
@@ -167,6 +167,28 @@ var allTestCases = map[string]testCase{
 			},
 		},
 	},
+	// adapted from https://github.com/corymhall/example-terraform-project
+	"aws_vpc": {
+		name: "aws_vpc",
+		dir:  "programs/aws_vpc",
+		assertions: map[string]assertion{
+			"vpc exists": func(output map[string]any) error {
+				if output["vpc"] == nil {
+					return fmt.Errorf("vpc is nil")
+				}
+				vpcId := output["vpc"].(string)
+
+				if len(vpcId) == 0 {
+					return fmt.Errorf("vpc id is empty")
+				}
+				_, err := run(".", "aws", "ec2", "describe-vpcs", "--filters", "Name=vpc-id,Values="+vpcId)
+				if err != nil {
+					return fmt.Errorf("failed to describe vpc: %w", err)
+				}
+				return nil
+			},
+		},
+	},
 	// adapted from https://github.com/hashicorp-education/learn-terraform-cloudflare-static-website
 	"cloudflare_aws_static_website": {
 		name:     "cloudflare_aws_static_website",

--- a/tests/benchmark/plans/aws_vpc/pulumi_plan_claude.out.json
+++ b/tests/benchmark/plans/aws_vpc/pulumi_plan_claude.out.json
@@ -1,0 +1,149 @@
+{
+  "resourcePlans": {
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/eip:Eip::nat-eip": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/internetGateway:InternetGateway::igw": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/natGateway:NatGateway::nat-gw": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/route:Route::private-route": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/route:Route::public-route": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/routeTable:RouteTable::database-rt": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/routeTable:RouteTable::private-rt": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/routeTable:RouteTable::public-rt": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/routeTableAssociation:RouteTableAssociation::database-rta-0": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/routeTableAssociation:RouteTableAssociation::database-rta-1": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/routeTableAssociation:RouteTableAssociation::database-rta-2": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/routeTableAssociation:RouteTableAssociation::private-rta-0": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/routeTableAssociation:RouteTableAssociation::private-rta-1": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/routeTableAssociation:RouteTableAssociation::private-rta-2": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/routeTableAssociation:RouteTableAssociation::public-rta-0": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/routeTableAssociation:RouteTableAssociation::public-rta-1": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/routeTableAssociation:RouteTableAssociation::public-rta-2": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/subnet:Subnet::database-a": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/subnet:Subnet::database-b": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/subnet:Subnet::database-c": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/subnet:Subnet::private-a": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/subnet:Subnet::private-b": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/subnet:Subnet::private-c": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/subnet:Subnet::public-a": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/subnet:Subnet::public-b": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/subnet:Subnet::public-c": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::aws:ec2/vpc:Vpc::vpc": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::pulumi:providers:aws::aws": {
+      "steps": [
+        "create"
+      ]
+    },
+    "urn:pulumi:test::terraform-aws-vpc-conversion::pulumi:pulumi:Stack::terraform-aws-vpc-conversion-test": {
+      "steps": [
+        "create"
+      ]
+    }
+  }
+}

--- a/tests/benchmark/plans/aws_vpc/tf_plan.out.json
+++ b/tests/benchmark/plans/aws_vpc/tf_plan.out.json
@@ -1,0 +1,113 @@
+{
+  "resource_changes": [
+    {
+      "type": "aws_db_subnet_group",
+      "name": "database"
+    },
+    {
+      "type": "aws_default_network_acl",
+      "name": "this"
+    },
+    {
+      "type": "aws_default_route_table",
+      "name": "default"
+    },
+    {
+      "type": "aws_default_security_group",
+      "name": "this"
+    },
+    {
+      "type": "aws_internet_gateway",
+      "name": "this"
+    },
+    {
+      "type": "aws_route",
+      "name": "public_internet_gateway"
+    },
+    {
+      "type": "aws_route_table",
+      "name": "private"
+    },
+    {
+      "type": "aws_route_table",
+      "name": "public"
+    },
+    {
+      "type": "aws_route_table_association",
+      "name": "database"
+    },
+    {
+      "type": "aws_route_table_association",
+      "name": "database"
+    },
+    {
+      "type": "aws_route_table_association",
+      "name": "database"
+    },
+    {
+      "type": "aws_route_table_association",
+      "name": "private"
+    },
+    {
+      "type": "aws_route_table_association",
+      "name": "private"
+    },
+    {
+      "type": "aws_route_table_association",
+      "name": "private"
+    },
+    {
+      "type": "aws_route_table_association",
+      "name": "public"
+    },
+    {
+      "type": "aws_route_table_association",
+      "name": "public"
+    },
+    {
+      "type": "aws_route_table_association",
+      "name": "public"
+    },
+    {
+      "type": "aws_subnet",
+      "name": "database"
+    },
+    {
+      "type": "aws_subnet",
+      "name": "database"
+    },
+    {
+      "type": "aws_subnet",
+      "name": "database"
+    },
+    {
+      "type": "aws_subnet",
+      "name": "private"
+    },
+    {
+      "type": "aws_subnet",
+      "name": "private"
+    },
+    {
+      "type": "aws_subnet",
+      "name": "private"
+    },
+    {
+      "type": "aws_subnet",
+      "name": "public"
+    },
+    {
+      "type": "aws_subnet",
+      "name": "public"
+    },
+    {
+      "type": "aws_subnet",
+      "name": "public"
+    },
+    {
+      "type": "aws_vpc",
+      "name": "this"
+    }
+  ],
+  "output_changes": null
+}

--- a/tests/benchmark/programs/aws_vpc/main.tf
+++ b/tests/benchmark/programs/aws_vpc/main.tf
@@ -1,0 +1,98 @@
+locals {
+  cidr_blocks = {
+    prd    = "10.6.0.0/16"
+    nonprd = "10.8.0.0/16"
+  }
+  env     = "prd"
+  region  = "us-east-1"
+  project = "aws_vpc"
+}
+
+provider "aws" {
+  region = local.region
+}
+
+//@pulumi-terraform-module subnetsmod
+module "subnets" {
+  source          = "hashicorp/subnets/cidr"
+  version         = "1.0.0"
+  base_cidr_block = local.cidr_blocks[local.env]
+  networks = [
+    {
+      name     = "private-a"
+      new_bits = 4
+    },
+    {
+      name     = "public-a"
+      new_bits = 4
+    },
+    {
+      name     = "database-a"
+      new_bits = 4
+    },
+    {
+      name     = "private-b"
+      new_bits = 4
+    },
+    {
+      name     = "public-b"
+      new_bits = 4
+    },
+    {
+      name     = "database-b"
+      new_bits = 4
+    },
+    {
+      name     = "private-c"
+      new_bits = 4
+    },
+    {
+      name     = "public-c"
+      new_bits = 4
+    },
+    {
+      name     = "database-c"
+      new_bits = 4
+    },
+  ]
+}
+
+//@pulumi-terraform-module vpcmod
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "6.0.1"
+
+  name = "${local.project}_${local.env}"
+  cidr = module.subnets.base_cidr_block
+
+  azs                   = ["${local.region}a", "${local.region}b", "${local.region}c"]
+  private_subnets       = [module.subnets.network_cidr_blocks["private-a"], module.subnets.network_cidr_blocks["private-b"], module.subnets.network_cidr_blocks["private-c"]]
+  private_subnet_suffix = "app"
+  private_subnet_tags = {
+    "subnet-type" = "app"
+  }
+
+  public_subnets       = [module.subnets.network_cidr_blocks["public-a"], module.subnets.network_cidr_blocks["public-b"], module.subnets.network_cidr_blocks["public-c"]]
+  public_subnet_suffix = "dmz"
+  public_subnet_tags = {
+    "subnet-type" = "dmz"
+  }
+
+  database_subnets       = [module.subnets.network_cidr_blocks["database-a"], module.subnets.network_cidr_blocks["database-b"], module.subnets.network_cidr_blocks["database-c"]]
+  database_subnet_suffix = "db"
+  database_subnet_tags = {
+    "subnet-type" = "db"
+  }
+
+  single_nat_gateway = true
+
+  tags = {
+    environment     = local.env
+    provisioner     = "Terraform"
+    (local.project) = "true"
+  }
+}
+
+output "vpc" {
+  value = module.vpc.vpc_id
+}


### PR DESCRIPTION
Adds an example with TF VPC modules.

based on https://github.com/corymhall/example-terraform-project

```
--------------------------------
tfResults:
total: 1
convertSuccesses: 1 (100%)
planSuccesses: 1 (100%)
planComparisonSuccesses: 1 (100%)
applySuccesses: 1 (100%)
assertSuccesses: 1 (100%)
claudeResults:
total: 1
convertSuccesses: 1 (100%)
planSuccesses: 1 (100%)
planComparisonSuccesses: 1 (100%)
applySuccesses: 1 (100%)
assertSuccesses: 1 (100%)
pulumiResultsTs:
total: 1
convertSuccesses: 0 (0%)
planSuccesses: 0 (0%)
planComparisonSuccesses: 0 (0%)
applySuccesses: 0 (0%)
assertSuccesses: 0 (0%)
```