### PR TITLE
Fix panic when complex indexer parts are encountered

### DIFF
--- a/pkg/convert/testdata/mappings/complex.json
+++ b/pkg/convert/testdata/mappings/complex.json
@@ -109,6 +109,23 @@
                         }
                     }
                 },
+                "inner_list_list_object": {
+                    "type": 5,
+                    "optional": true,
+                    "element": {
+                        "schema": {
+                            "type": 5,
+                            "element": {
+                                "resource": {
+                                    "inner_string": {
+                                        "type": 4,
+                                        "optional": true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "inner_map_object": {
                     "type": 6,
                     "optional": true,

--- a/pkg/convert/testdata/programs/complex_resource/main.tf
+++ b/pkg/convert/testdata/programs/complex_resource/main.tf
@@ -1,20 +1,24 @@
 resource "complex_resource" "a_resource" {
-    a_bool = true
-    a_number = 2.3
-    a_string = "hello world"
-    a_list_of_int = [1, 2, 3]
-    a_map_of_bool = {
-        a: true
-        b: false
-    }
-    inner_list_object = [{
-        inner_string = "hello again"
-    }]
-    inner_map_object = {
-        inner_string = "hello thrice"
-    }
+  a_bool        = true
+  a_number      = 2.3
+  a_string      = "hello world"
+  a_list_of_int = [1, 2, 3]
+  a_map_of_bool = {
+    a : true
+    b : false
+  }
+  inner_list_list_object = [[{
+    inner_string = "hello"
+  }]]
+  inner_list_object = [{
+    inner_string = "hello again"
+  }]
+  inner_map_object = {
+    inner_string = "hello thrice"
+  }
 }
 
 output "some_output" {
-    value = complex_resource.a_resource.result
+  value = complex_resource.a_resource.result
 }
+

--- a/pkg/convert/testdata/programs/complex_resource/pcl/main.pp
+++ b/pkg/convert/testdata/programs/complex_resource/pcl/main.pp
@@ -8,6 +8,9 @@ resource "aResource" "complex:index/index:resource" {
     a = true
     b = false
   }
+  innerListListObjects = [[{
+    innerString = "hello"
+  }]]
   innerListObject = {
     innerString = "hello again"
   }

--- a/pkg/convert/testdata/schemas/complex.json
+++ b/pkg/convert/testdata/schemas/complex.json
@@ -34,6 +34,14 @@
       },
       "type": "object"
     },
+    "complex:index/resourceInnerListListObject:resourceInnerListListObject": {
+      "properties": {
+        "innerString": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "complex:index/resourceInnerListObject:resourceInnerListObject": {
       "properties": {
         "innerString": {
@@ -81,6 +89,15 @@
         "aString": {
           "type": "string"
         },
+        "innerListListObjects": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/types/complex:index/resourceInnerListListObject:resourceInnerListListObject"
+            }
+          }
+        },
         "innerListObject": {
           "$ref": "#/types/complex:index/resourceInnerListObject:resourceInnerListObject"
         },
@@ -116,6 +133,15 @@
         "aString": {
           "type": "string"
         },
+        "innerListListObjects": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/types/complex:index/resourceInnerListListObject:resourceInnerListListObject"
+            }
+          }
+        },
         "innerListObject": {
           "$ref": "#/types/complex:index/resourceInnerListObject:resourceInnerListObject"
         },
@@ -146,6 +172,15 @@
           },
           "aString": {
             "type": "string"
+          },
+          "innerListListObjects": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/types/complex:index/resourceInnerListListObject:resourceInnerListListObject"
+              }
+            }
           },
           "innerListObject": {
             "$ref": "#/types/complex:index/resourceInnerListObject:resourceInnerListObject"

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -1220,7 +1220,7 @@ func convertObjectConsExpr(state *convertState, inBlock bool, scopes *scopes,
 					// We either don't know this type, or know it's not a map, so we should try to rename the keys.
 					subQualifiedPath = appendPath(fullyQualifiedPath, *name)
 					if state.rewriteObjectKeys {
-						*name = scopes.pulumiName(subQualifiedPath)
+						*name = scopes.pulumiName(*name, subQualifiedPath)
 					}
 				}
 
@@ -1467,7 +1467,7 @@ func rewriteRelativeTraversal(scopes *scopes, fullyQualifiedPath string, travers
 		var name string
 		if fullyQualifiedPath != "" {
 			fullyQualifiedPath = appendPath(fullyQualifiedPath, attr.Name)
-			name = scopes.pulumiName(fullyQualifiedPath)
+			name = scopes.pulumiName(name, fullyQualifiedPath)
 		} else {
 			name = tfbridge.TerraformToPulumiNameV2(attr.Name, nil, nil)
 		}
@@ -2114,7 +2114,7 @@ func convertBody(state *convertState, scopes *scopes, fullyQualifiedPath string,
 		}
 		// If this is a list so add [] to the path
 		isList := !scopes.maxItemsOne(blockPath) && !scopes.isResource(blockPath)
-		name := scopes.pulumiName(blockPath)
+		name := scopes.pulumiName("", blockPath)
 		if isList {
 			blockPath = appendPathArray(blockPath)
 		}
@@ -2236,7 +2236,7 @@ func convertBody(state *convertState, scopes *scopes, fullyQualifiedPath string,
 
 		var name string
 		if state.rewriteObjectKeys {
-			name = scopes.pulumiName(attrPath)
+			name = scopes.pulumiName(attr.Name, attrPath)
 		} else {
 			name = attr.Name
 		}


### PR DESCRIPTION
This handles the case reported in #363 where a complex indexer part is
encountered (e.g. in `alicloud_message_service_event_rule.default.match_rules[][].name` - `[][]` represents a complex indexer)

This PR removes the panic and adds fallback logic to default to
camelCasing the Terraform name.

fixes #363