### PR TITLE
Handle camelCasing string keys when indexing objects

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,3 +2,4 @@
 
 ### Bug Fixes
  - Handle attributes with complex indexer parts by falling back to camelCasing the attribute name if the name cannot be determined.
+ - Handle camelCasing string keys when indexing objects

--- a/pkg/convert/testdata/programs/for_each/main.tf
+++ b/pkg/convert/testdata/programs/for_each/main.tf
@@ -1,3 +1,9 @@
+locals {
+    values = {
+        something = { some_key = "some-value" }
+        "something-else" = { some_key = "some-value" }
+    }
+}
 resource "simple_resource" "a_resource_with_foreach_map" {
     for_each = {
         cruel: "world"
@@ -28,6 +34,16 @@ resource "simple_resource" "a_resource_with_foreach_array" {
     for_each = ["cruel", "good"]
     input_one =  "Hello ${each.value} world"
     input_two = true
+}
+
+resource "simple_resource" "a_resource_with_foreach_object_access" {
+    for_each = local.values
+    input_one =  each.value.some_key
+}
+
+resource "simple_resource" "a_resource_with_foreach_object_index" {
+    for_each = local.values
+    input_one =  each.value["some_key"]
 }
 
 output "some_output_c" {

--- a/pkg/convert/testdata/programs/for_each/pcl/main.pp
+++ b/pkg/convert/testdata/programs/for_each/pcl/main.pp
@@ -1,3 +1,11 @@
+values = {
+  something = {
+    someKey = "some-value"
+  }
+  "something-else" = {
+    someKey = "some-value"
+  }
+}
 resource "aResourceWithForeachMap" "simple:index:resource" {
   __logicalName = "a_resource_with_foreach_map"
   options {
@@ -33,6 +41,22 @@ resource "aResourceWithForeachArray" "simple:index:resource" {
   }
   inputOne = "Hello ${range.value} world"
   inputTwo = true
+}
+
+resource "aResourceWithForeachObjectAccess" "simple:index:resource" {
+  __logicalName = "a_resource_with_foreach_object_access"
+  options {
+    range = values
+  }
+  inputOne = range.value.someKey
+}
+
+resource "aResourceWithForeachObjectIndex" "simple:index:resource" {
+  __logicalName = "a_resource_with_foreach_object_index"
+  options {
+    range = values
+  }
+  inputOne = range.value.someKey
 }
 
 output "someOutputC" {

--- a/pkg/convert/testdata/programs/for_each_module/pcl/main.pp
+++ b/pkg/convert/testdata/programs/for_each_module/pcl/main.pp
@@ -9,7 +9,7 @@ component "aModuleWithForeachMap" "./modules/simple" {
 }
 
 output "someOutputA" {
-  value = aModuleWithForeachMap["cruel"].output
+  value = aModuleWithForeachMap.cruel.output
 }
 
 component "aModuleWithForeachArray" "./modules/simple" {
@@ -20,5 +20,5 @@ component "aModuleWithForeachArray" "./modules/simple" {
 }
 
 output "someOutputB" {
-  value = aModuleWithForeachArray["good"].output
+  value = aModuleWithForeachArray.good.output
 }

--- a/pkg/convert/testdata/states/count/import.json
+++ b/pkg/convert/testdata/states/count/import.json
@@ -1,9 +1,9 @@
 [
   {
     "Type": "simple:index:resource",
-    "Name": "a_resource_0",
-    "ID": "abc123",
-    "LogicalName": "a_resource-0",
+    "Name": "a_resource_1",
+    "ID": "def456",
+    "LogicalName": "a_resource-1",
     "IsComponent": false,
     "IsRemote": false,
     "Version": "",
@@ -11,9 +11,9 @@
   },
   {
     "Type": "simple:index:resource",
-    "Name": "a_resource_1",
-    "ID": "def456",
-    "LogicalName": "a_resource-1",
+    "Name": "a_resource_0",
+    "ID": "abc123",
+    "LogicalName": "a_resource-0",
     "IsComponent": false,
     "IsRemote": false,
     "Version": "",


### PR DESCRIPTION
This handles two different cases of indexing objects.

- Cases using `IndexExpr`
- Cases using "relative traversals"

Let me know if there are more cases that I am missing.

I've also taken the approach of rewriting the index access from
`object["myValue"]` to `object.myValue`, but let me know if you don't
like this optimization and I can remove it.

fixes #373