### PR TITLE
Remove pulumi-wavefront from list of pulumi-supported providers

### DIFF
--- a/pkg/convert/pulumiverse.go
+++ b/pkg/convert/pulumiverse.go
@@ -127,7 +127,6 @@ var pulumiSupportedProviders = []string{
 	"venafi",
 	"vra",
 	"vsphere",
-	"wavefront",
 	"xyz",
 	"zitadel",
 }


### PR DESCRIPTION
We are deprecating pulumi-wavefront.
We should remove it from the supported list so that conversions can occur via downloading the latest upstream from opentofu.

Part of https://github.com/pulumi/pulumi-wavefront/issues/772.

