### PR TITLE
Emit the new style of PCL `package` blocks

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -17,3 +17,6 @@
 
 - Fix `self.X` references inside `provisioner` blocks being converted to an undefined variable. They
   now resolve to the Pulumi-renamed attribute on the parent resource.
+
+- Stop emitting deprecated package block labels in generated PCL, using the `baseProviderName` attribute instead.
+  [#405](https://github.com/pulumi/pulumi-converter-terraform/pull/405)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -14,3 +14,6 @@
   `customTimeouts` option on the generated resource.
   [#104](https://github.com/pulumi/pulumi-converter-terraform/issues/104)
   [#184](https://github.com/pulumi/pulumi-converter-terraform/issues/184)
+
+- Stop emitting deprecated package block labels in generated PCL, using the
+  `baseProviderName` attribute instead.  [#405](https://github.com/pulumi/pulumi-converter-terraform/pull/405)

--- a/pkg/convert/testdata/programs/implicit_required_providers/pcl/diagnostics.json
+++ b/pkg/convert/testdata/programs/implicit_required_providers/pcl/diagnostics.json
@@ -1,3 +1,0 @@
-[
-  "warning:main.pp:0,8-13:package block label is deprecated:Package block labels should be replaced by baseProviderName."
-]

--- a/pkg/convert/testdata/programs/implicit_required_providers/pcl/main.pp
+++ b/pkg/convert/testdata/programs/implicit_required_providers/pcl/main.pp
@@ -1,4 +1,4 @@
-package "tfe" {
+package {
   baseProviderName    = "terraform-provider"
   baseProviderVersion = "0.8.1"
   parameterization {

--- a/pkg/convert/testdata/programs/pulumi-terraform-local-module/pcl/diagnostics.json
+++ b/pkg/convert/testdata/programs/pulumi-terraform-local-module/pcl/diagnostics.json
@@ -1,3 +1,0 @@
-[
-  "warning:main.pp:0,8-17:package block label is deprecated:Package block labels should be replaced by baseProviderName."
-]

--- a/pkg/convert/testdata/programs/pulumi-terraform-local-module/pcl/main.pp
+++ b/pkg/convert/testdata/programs/pulumi-terraform-local-module/pcl/main.pp
@@ -1,4 +1,4 @@
-package "example" {
+package {
   baseProviderName    = "terraform-module"
   baseProviderVersion = "0.1.4"
   parameterization {

--- a/pkg/convert/testdata/programs/required_providers/pcl/diagnostics.json
+++ b/pkg/convert/testdata/programs/required_providers/pcl/diagnostics.json
@@ -1,4 +1,0 @@
-[
-  "warning:main.pp:0,8-14:package block label is deprecated:Package block labels should be replaced by baseProviderName.",
-  "warning:main.pp:4,9-17:package block label is deprecated:Package block labels should be replaced by baseProviderName."
-]

--- a/pkg/convert/testdata/programs/required_providers/pcl/main.pp
+++ b/pkg/convert/testdata/programs/required_providers/pcl/main.pp
@@ -1,8 +1,8 @@
-package "null" {
+package {
   baseProviderName = "null"
 }
 
-package "random" {
+package {
   baseProviderName = "random"
 }
 

--- a/pkg/convert/testdata/programs/required_providers_tf/pcl/diagnostics.json
+++ b/pkg/convert/testdata/programs/required_providers_tf/pcl/diagnostics.json
@@ -1,3 +1,0 @@
-[
-  "warning:main.pp:0,8-18:package block label is deprecated:Package block labels should be replaced by baseProviderName."
-]

--- a/pkg/convert/testdata/programs/required_providers_tf/pcl/main.pp
+++ b/pkg/convert/testdata/programs/required_providers_tf/pcl/main.pp
@@ -1,4 +1,4 @@
-package "boundary" {
+package {
   baseProviderName    = "terraform-provider"
   baseProviderVersion = "0.8.1"
   parameterization {

--- a/pkg/convert/testdata/programs/sandbox_multiple_registry_modules/pcl/diagnostics.json
+++ b/pkg/convert/testdata/programs/sandbox_multiple_registry_modules/pcl/diagnostics.json
@@ -1,3 +1,0 @@
-[
-  "warning:main.pp:0,8-17:package block label is deprecated:Package block labels should be replaced by baseProviderName."
-]

--- a/pkg/convert/testdata/programs/sandbox_multiple_registry_modules/pcl/main.pp
+++ b/pkg/convert/testdata/programs/sandbox_multiple_registry_modules/pcl/main.pp
@@ -1,4 +1,4 @@
-package "subnets" {
+package {
   baseProviderName    = "terraform-module"
   baseProviderVersion = "0.1.4"
   parameterization {

--- a/pkg/convert/testdata/programs/sandbox_registry_module/pcl/diagnostics.json
+++ b/pkg/convert/testdata/programs/sandbox_registry_module/pcl/diagnostics.json
@@ -1,3 +1,0 @@
-[
-  "warning:main.pp:0,8-17:package block label is deprecated:Package block labels should be replaced by baseProviderName."
-]

--- a/pkg/convert/testdata/programs/sandbox_registry_module/pcl/main.pp
+++ b/pkg/convert/testdata/programs/sandbox_registry_module/pcl/main.pp
@@ -1,4 +1,4 @@
-package "subnets" {
+package {
   baseProviderName    = "terraform-module"
   baseProviderVersion = "0.1.4"
   parameterization {

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -3948,7 +3948,7 @@ func translateModuleSourceCode(
 
 // getPackageBlock returns package block in the following form:
 //
-//	package <name> {
+//	package {
 //	  baseProviderName = <name>
 //	  baseProviderVersion = <version>
 //	  baseProviderDownloadUrl = <url>
@@ -3976,7 +3976,7 @@ func getPackageBlock(name string, prov *configs.RequiredProvider) (*hclwrite.Blo
 	// parlance). This may lead to name overlap, but as of now this is how our system works. If we need to fix name
 	// overlap, this is the place to start.
 	_ = name
-	block := hclwrite.NewBlock("package", []string{packageName})
+	block := hclwrite.NewBlock("package", []string{})
 	body := block.Body()
 
 	diags := hcl.Diagnostics{}
@@ -4017,7 +4017,7 @@ func remotePulumiTerraformModulePackageBlock(
 	source addrs.ModuleSourceRegistry,
 	version string,
 ) *hclwrite.Block {
-	block := hclwrite.NewBlock("package", []string{packageName})
+	block := hclwrite.NewBlock("package", []string{})
 	body := block.Body()
 	body.SetAttributeValue("baseProviderName", cty.StringVal("terraform-module"))
 	body.SetAttributeValue("baseProviderVersion", cty.StringVal("0.1.4"))
@@ -4054,7 +4054,7 @@ func localPulumiTerraformModulePackageBlock(
 	packageName string,
 	localPath string,
 ) *hclwrite.Block {
-	block := hclwrite.NewBlock("package", []string{packageName})
+	block := hclwrite.NewBlock("package", []string{})
 	body := block.Body()
 	body.SetAttributeValue("baseProviderName", cty.StringVal("terraform-module"))
 	body.SetAttributeValue("baseProviderVersion", cty.StringVal("0.1.4"))

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -4865,7 +4865,7 @@ func translateModuleSourceCode(
 
 // getPackageBlock returns package block in the following form:
 //
-//	package <name> {
+//	package {
 //	  baseProviderName = <name>
 //	  baseProviderVersion = <version>
 //	  baseProviderDownloadUrl = <url>
@@ -4893,7 +4893,7 @@ func getPackageBlock(name string, prov *configs.RequiredProvider) (*hclwrite.Blo
 	// parlance). This may lead to name overlap, but as of now this is how our system works. If we need to fix name
 	// overlap, this is the place to start.
 	_ = name
-	block := hclwrite.NewBlock("package", []string{packageName})
+	block := hclwrite.NewBlock("package", []string{})
 	body := block.Body()
 
 	diags := hcl.Diagnostics{}
@@ -4934,7 +4934,7 @@ func remotePulumiTerraformModulePackageBlock(
 	source addrs.ModuleSourceRegistry,
 	version string,
 ) *hclwrite.Block {
-	block := hclwrite.NewBlock("package", []string{packageName})
+	block := hclwrite.NewBlock("package", []string{})
 	body := block.Body()
 	body.SetAttributeValue("baseProviderName", cty.StringVal("terraform-module"))
 	body.SetAttributeValue("baseProviderVersion", cty.StringVal("0.1.4"))
@@ -4971,7 +4971,7 @@ func localPulumiTerraformModulePackageBlock(
 	packageName string,
 	localPath string,
 ) *hclwrite.Block {
-	block := hclwrite.NewBlock("package", []string{packageName})
+	block := hclwrite.NewBlock("package", []string{})
 	body := block.Body()
 	body.SetAttributeValue("baseProviderName", cty.StringVal("terraform-module"))
 	body.SetAttributeValue("baseProviderVersion", cty.StringVal("0.1.4"))


### PR DESCRIPTION
This removes a diagnostic warning for the new style of package block introduced in `v3.228.0`. The fix needs all PCL consumers (language plugins) to understand the new syntax before it is safe to merge.