### PR TITLE
Don't use `entries`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,3 +11,6 @@
   [#60](https://github.com/pulumi/pulumi-converter-terraform/issues/60)
 
 ### Bug Fixes
+
+- Fix dynamic blocks with list-typed `for_each` incorrectly wrapping the collection in `entries()`.
+  [#414](https://github.com/pulumi/pulumi-converter-terraform/issues/414)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# Conformance Tests
+
+Before working on a conformance test, read the conformance test readme at
+`tests/conformance/README.md`.

--- a/pkg/convert/testdata/programs/dynamic/pcl/main.pp
+++ b/pkg/convert/testdata/programs/dynamic/pcl/main.pp
@@ -1,20 +1,20 @@
 resource "aResource" "blocks:index/index:resource" {
   __logicalName = "a_resource"
-  aListOfResources = [for entry in entries(["hi", "bye"]) : {
-    innerString = entry.value
+  aListOfResources = [for entry in ["hi", "bye"] : {
+    innerString = entry
   }]
 }
 
 resource "bResource" "blocks:index/index:resource" {
   __logicalName = "b_resource"
-  aListOfResources = [for entry in entries(["hi", "bye"]) : {
-    innerString = entry.value
+  aListOfResources = [for entry in ["hi", "bye"] : {
+    innerString = entry
   }]
 }
 
 resource "cResource" "blocks:index/index:resource" {
   __logicalName = "c_resource"
-  aListOfResources = [for entry in entries(["hi", "bye"]) : {
-    innerString = entry.value
+  aListOfResources = [for entry in ["hi", "bye"] : {
+    innerString = entry
   }]
 }

--- a/pkg/convert/testdata/programs/dynamic_max_items_one/pcl/main.pp
+++ b/pkg/convert/testdata/programs/dynamic_max_items_one/pcl/main.pp
@@ -1,5 +1,5 @@
 resource "main" "maxItemsOne:index/index:resource" {
-  innerResource = singleOrNone([for entry in entries([true]) : {
+  innerResource = singleOrNone([for entry in [true] : {
     someInput = true
   }])
 }

--- a/pkg/convert/testdata/programs/dynamic_nested_for_each/pcl/main.pp
+++ b/pkg/convert/testdata/programs/dynamic_nested_for_each/pcl/main.pp
@@ -11,14 +11,14 @@ resource "aResource" "blocks:index/index:resource" {
   options {
     range = length(listvar) > 0 ? 1 : 0
   }
-  aListOfResources = [for entry in entries(dynvar) : {
-    innerResources = [for entry2 in entries(entry.value.innerList) : {
+  aListOfResources = [for entry in dynvar : {
+    innerResources = [for entry2 in entry.innerList : {
 
       # Utilize the inner resource in the inner dynamic block, this
       # worked even before pulumi/pulumi#18718 was fixed.
-      nestedString = entry2.value.nestedValue
+      nestedString = entry2.nestedValue
     }]
-    innerString = entry.value.innerValue != null ? "TrySuccess" : "TryFail"
+    innerString = entry.innerValue != null ? "TrySuccess" : "TryFail"
   }]
 }
 
@@ -27,14 +27,14 @@ resource "bResource" "blocks:index/index:resource" {
   options {
     range = length(listvar) > 0 ? 1 : 0
   }
-  aListOfResources = [for entry in entries(dynvar) : {
-    innerResources = [for entry2 in entries(entry.value.innerList) : {
+  aListOfResources = [for entry in dynvar : {
+    innerResources = [for entry2 in entry.innerList : {
 
       # This was fixed by pulumi/pulumi#18718.  Before the generated
       # PCL would shadow a_list_of_resources with the same iterator
       # name (entry). 
-      nestedString = entry.value.innerValue
+      nestedString = entry.innerValue
     }]
-    innerString = entry.value.innerValue != null ? "TrySuccess" : "TryFail"
+    innerString = entry.innerValue != null ? "TrySuccess" : "TryFail"
   }]
 }

--- a/pkg/convert/testdata/programs/object_config_rename/pcl/main.pp
+++ b/pkg/convert/testdata/programs/object_config_rename/pcl/main.pp
@@ -62,14 +62,14 @@ resource "usingMapObjectConfigForEach" "simple:index:resource" {
 
 resource "usingDynamic" "blocks:index/index:resource" {
   __logicalName = "using_dynamic"
-  aListOfResources = [for entry in entries(objectMapConfig) : {
-    innerString = entry.value.firstMember
+  aListOfResources = [for entry in objectMapConfig : {
+    innerString = entry.firstMember
   }]
 }
 
 resource "usingDynamicIterator" "blocks:index/index:resource" {
   __logicalName = "using_dynamic_iterator"
-  aListOfResources = [for entry in entries(objectMapConfig) : {
-    innerString = entry.value.firstMember
+  aListOfResources = [for entry in objectMapConfig : {
+    innerString = entry.firstMember
   }]
 }

--- a/pkg/convert/testdata/programs/rename_lists/pcl/main.pp
+++ b/pkg/convert/testdata/programs/rename_lists/pcl/main.pp
@@ -23,7 +23,7 @@ resource "listBlockResource" "renames:index/index:resource" {
 // Check that lists as dynamics are handled correctly
 resource "listDynamicResource" "renames:index/index:resource" {
   __logicalName = "list_dynamic_resource"
-  theList = [for entry in entries([1, 2]) : {
-    number = entry.value
+  theList = [for entry in [1, 2] : {
+    number = entry
   }]
 }

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -1261,6 +1261,16 @@ func makeToken(typ hclsyntax.TokenType, str string) *hclwrite.Token {
 	}
 }
 
+// tokensContainIdent reports whether tokens contains an identifier token matching name.
+func tokensContainIdent(tokens hclwrite.Tokens, name string) bool {
+	for _, t := range tokens {
+		if t.Type == hclsyntax.TokenIdent && string(t.Bytes) == name {
+			return true
+		}
+	}
+	return false
+}
+
 func convertTemplateWrapExpr(state *convertState,
 	scopes *scopes, fullyQualifiedPath string, expr *hclsyntax.TemplateWrapExpr,
 ) hclwrite.Tokens {
@@ -1610,6 +1620,11 @@ func rewriteTraversal(
 			if localName != "" {
 				newTraversal = append(newTraversal, hcl.TraverseRoot{Name: localName})
 				newTraversal = append(newTraversal, rewriteRelativeTraversal(scopes, "", traversal[1:])...)
+			} else if dottedName := scopes.lookup("each." + maybeFirstAttr.Name); dottedName != "" {
+				// A dynamic block with iterator = "each" puts "each.value" and
+				// "each.key" into scope as dotted paths.
+				newTraversal = append(newTraversal, hcl.TraverseRoot{Name: dottedName})
+				newTraversal = append(newTraversal, rewriteRelativeTraversal(scopes, "", traversal[2:])...)
 			} else {
 				switch maybeFirstAttr.Name {
 				case "key":
@@ -2128,38 +2143,48 @@ func convertBody(state *convertState, scopes *scopes, fullyQualifiedPath string,
 				tfEachVar = block.Labels[0]
 			}
 
-			pulumiEachVar, cleanup := scopes.addNestedScopeUniqueName("entry", "", "")
-			defer cleanup()
+			pulumiEachVal, cleanupVal := scopes.addNestedScopeUniqueName("entry", "", "")
+			defer cleanupVal()
 
-			dynamicTokens := hclwrite.Tokens{makeToken(hclsyntax.TokenOBrack, "[")}
-			dynamicTokens = append(dynamicTokens, makeToken(hclsyntax.TokenIdent, "for"))
-			dynamicTokens = append(dynamicTokens, makeToken(hclsyntax.TokenIdent, pulumiEachVar))
-			dynamicTokens = append(dynamicTokens, makeToken(hclsyntax.TokenIdent, "in"))
+			pulumiEachKey, cleanupKey := scopes.addNestedScopeUniqueName("key", "", "")
+			defer cleanupKey()
 
 			forEachAttr, hasForEachAttr := dynamicBody.Attributes["for_each"]
 			if !hasForEachAttr {
 				continue
 			}
 
-			// wrap the collection expression into `entries(collection)` so that each entry has key and value
-			forEachExprTokens := convertExpression(state, true, scopes, fullyQualifiedPath, forEachAttr.Expr)
-			dynamicTokens = append(dynamicTokens, makeToken(hclsyntax.TokenIdent, "entries"))
-			dynamicTokens = append(dynamicTokens, makeToken(hclsyntax.TokenOParen, "("))
-			dynamicTokens = append(dynamicTokens, forEachExprTokens...)
-			dynamicTokens = append(dynamicTokens, makeToken(hclsyntax.TokenCParen, ")"))
-			dynamicTokens = append(dynamicTokens, makeToken(hclsyntax.TokenColon, ":"))
-
+			// Convert the body first so we can check whether the key
+			// variable is actually referenced.
 			bodyTokens := hclwrite.Tokens{makeToken(hclsyntax.TokenIdent, "{}")}
 			for _, innerBlock := range dynamicBody.Blocks {
 				if innerBlock.Type == "content" {
 					scopes.push(map[string]string{
-						tfEachVar: pulumiEachVar,
+						tfEachVar + ".value": pulumiEachVal,
+						tfEachVar + ".key":   pulumiEachKey,
 					})
 					contentBody := convertBody(state, scopes, blockPath, innerBlock.Body)
 					bodyTokens = tokensForObject(contentBody)
 					scopes.pop()
 				}
 			}
+
+			// Build [for key, val in collection: body] or
+			// [for val in collection: body] depending on whether the
+			// key variable was used. The two-variable form handles both
+			// maps and lists without needing entries().
+			dynamicTokens := hclwrite.Tokens{makeToken(hclsyntax.TokenOBrack, "[")}
+			dynamicTokens = append(dynamicTokens, makeToken(hclsyntax.TokenIdent, "for"))
+			if tokensContainIdent(bodyTokens, pulumiEachKey) {
+				dynamicTokens = append(dynamicTokens, makeToken(hclsyntax.TokenIdent, pulumiEachKey))
+				dynamicTokens = append(dynamicTokens, makeToken(hclsyntax.TokenComma, ","))
+			}
+			dynamicTokens = append(dynamicTokens, makeToken(hclsyntax.TokenIdent, pulumiEachVal))
+			dynamicTokens = append(dynamicTokens, makeToken(hclsyntax.TokenIdent, "in"))
+
+			forEachExprTokens := convertExpression(state, true, scopes, fullyQualifiedPath, forEachAttr.Expr)
+			dynamicTokens = append(dynamicTokens, forEachExprTokens...)
+			dynamicTokens = append(dynamicTokens, makeToken(hclsyntax.TokenColon, ":"))
 
 			dynamicTokens = append(dynamicTokens, bodyTokens...)
 			dynamicTokens = append(dynamicTokens, makeToken(hclsyntax.TokenCBrack, "]"))

--- a/tests/conformance/l2_dynamic_block_list_for_each_test.go
+++ b/tests/conformance/l2_dynamic_block_list_for_each_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-converter-terraform/pkg/testing/conformance"
+	"github.com/pulumi/pulumi-converter-terraform/tests/conformance/providers"
+)
+
+// TestL2DynamicBlockListForEach reproduces a converter bug where dynamic blocks
+// with list-typed for_each expressions get wrapped in entries(), which fails at
+// runtime because entries() only works on maps. References inside the block also
+// become doubly nested (e.g. rule.value.value.port instead of rule.value.port).
+func TestL2DynamicBlockListForEach(t *testing.T) {
+	// https://github.com/pulumi/pulumi-converter-terraform/issues/414
+	t.Parallel()
+	conformance.AssertConversion(t, conformance.TestCase{
+		Providers: []conformance.Provider{
+			{Name: "test", Factory: providers.TestProvider},
+		},
+		Input: map[string]string{"main.tf": `
+variable "rules" {
+  type = list(object({
+    port     = number
+    protocol = string
+  }))
+  default = [
+    { port = 80, protocol = "tcp" },
+    { port = 443, protocol = "tcp" }
+  ]
+}
+
+resource "test_nested_resource" "example" {
+  value = "test"
+
+  dynamic "rule" {
+    for_each = var.rules
+    content {
+      port     = rule.value.port
+      protocol = rule.value.protocol
+    }
+  }
+}
+
+output "computed" {
+  value = test_nested_resource.example.computed_value
+}
+`},
+	})
+}

--- a/tests/conformance/l2_dynamic_block_map_for_each_test.go
+++ b/tests/conformance/l2_dynamic_block_map_for_each_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-converter-terraform/pkg/testing/conformance"
+	"github.com/pulumi/pulumi-converter-terraform/tests/conformance/providers"
+)
+
+// TestL2DynamicBlockMapForEach tests dynamic blocks with a map-typed for_each
+// where the body references both the key and value of each entry.
+func TestL2DynamicBlockMapForEach(t *testing.T) {
+	t.Parallel()
+	conformance.AssertConversion(t, conformance.TestCase{
+		Providers: []conformance.Provider{
+			{Name: "test", Factory: providers.TestProvider},
+		},
+		Input: map[string]string{"main.tf": `
+variable "rule_map" {
+  type = map(object({
+    port = number
+  }))
+  default = {
+    "tcp" = { port = 80 }
+    "udp" = { port = 53 }
+  }
+}
+
+resource "test_nested_resource" "example" {
+  value = "test"
+
+  dynamic "rule" {
+    for_each = var.rule_map
+    content {
+      port     = rule.value.port
+      protocol = rule.key
+    }
+  }
+}
+
+output "computed" {
+  value = test_nested_resource.example.computed_value
+}
+`},
+	})
+}

--- a/tests/conformance/providers/test.go
+++ b/tests/conformance/providers/test.go
@@ -16,6 +16,7 @@ package providers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -54,6 +55,54 @@ func TestProvider() *schema.Provider {
 						return diag.FromErr(err)
 					}
 					if err := d.Set("computed_list", []string{"x", "y"}); err != nil {
+						return diag.FromErr(err)
+					}
+					return nil
+				},
+				ReadContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics {
+					return nil
+				},
+				UpdateContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics {
+					return nil
+				},
+				DeleteContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics {
+					return nil
+				},
+			},
+			// test_nested_resource has a nested block so that dynamic blocks can
+			// be tested.
+			"test_nested_resource": {
+				Schema: map[string]*schema.Schema{
+					"value": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"rule": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"port": {
+									Type:     schema.TypeInt,
+									Required: true,
+								},
+								"protocol": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+							},
+						},
+					},
+					"computed_value": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+				},
+				CreateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					d.SetId("nested-id")
+					v := d.Get("value").(string)
+					rules := d.Get("rule").([]any)
+					if err := d.Set("computed_value", fmt.Sprintf("computed(%s,%s)", v, rules)); err != nil {
 						return diag.FromErr(err)
 					}
 					return nil

--- a/tests/conformance/testdata/TestL2DynamicBlockListForEach/main.pp
+++ b/tests/conformance/testdata/TestL2DynamicBlockListForEach/main.pp
@@ -1,0 +1,21 @@
+config "rules" "list(object({port=number, protocol=string}))" {
+  default = [{
+    port     = 80
+    protocol = "tcp"
+    }, {
+    port     = 443
+    protocol = "tcp"
+  }]
+}
+
+resource "example" "test:index/nestedResource:NestedResource" {
+  rules = [for entry in rules : {
+    port     = entry.port
+    protocol = entry.protocol
+  }]
+  value = "test"
+}
+
+output "computed" {
+  value = example.computedValue
+}

--- a/tests/conformance/testdata/TestL2DynamicBlockMapForEach/main.pp
+++ b/tests/conformance/testdata/TestL2DynamicBlockMapForEach/main.pp
@@ -1,0 +1,22 @@
+config "ruleMap" "map(object({port=number}))" {
+  default = {
+    tcp = {
+      port = 80
+    }
+    udp = {
+      port = 53
+    }
+  }
+}
+
+resource "example" "test:index/nestedResource:NestedResource" {
+  rules = [for key, entry in ruleMap : {
+    port     = entry.port
+    protocol = key
+  }]
+  value = "test"
+}
+
+output "computed" {
+  value = example.computedValue
+}


### PR DESCRIPTION
Both new conformance tests fail without the change, but pass with the change. This also cleans up the generation for a lot of code that iterates over a list, since that doesn't need entries, just normal list comprehension.

Fixes #414