### PR TITLE
Fix the provisioner referencing `self`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -14,3 +14,6 @@
 
 - Fix dynamic blocks with list-typed `for_each` incorrectly wrapping the collection in `entries()`.
   [#414](https://github.com/pulumi/pulumi-converter-terraform/issues/414)
+
+- Fix `self.X` references inside `provisioner` blocks being converted to an undefined variable. They
+  now resolve to the Pulumi-renamed attribute on the parent resource.

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -1614,6 +1614,21 @@ func rewriteTraversal(
 				})
 				return nil
 			}
+		} else if root.Name == "self" && maybeFirstAttr != nil {
+			if scopes.self != nil {
+				newTraversal = append(newTraversal, scopes.self...)
+				newTraversal = append(newTraversal, rewriteRelativeTraversal(scopes, scopes.selfPath, traversal[1:])...)
+			} else {
+				state.appendDiagnostic(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  `Reference to "self" outside of a provisioner block`,
+					Detail: `The "self" object can only be used inside "provisioner" and "connection" blocks, ` +
+						`and refers to the resource to which the provisioner is attached.`,
+					Context: &subjectRange,
+					Subject: &contextRange,
+				})
+				return nil
+			}
 		} else if root.Name == "each" && maybeFirstAttr != nil {
 			// This _might_ be the special "each" value or it might just be a local, check the latter first
 			localName := scopes.lookup("each")
@@ -2527,7 +2542,7 @@ func convertProvisioner(
 	state *convertState,
 	info ProviderInfoSource, scopes *scopes,
 	provisioner *configs.Provisioner,
-	resourceName string, provisionerIndex int,
+	resourceName string, resourcePath string, provisionerIndex int,
 	forEach hcl.Expression,
 	target *hclwrite.Body,
 ) {
@@ -2577,6 +2592,10 @@ func convertProvisioner(
 	}
 
 	optionsBlockBody.SetAttributeRaw("dependsOn", dependsOn)
+
+	scopes.self = hcl.Traversal{hcl.TraverseRoot{Name: resourceName}}
+	scopes.selfPath = resourcePath
+	defer func() { scopes.self, scopes.selfPath = nil, "" }()
 
 	attributes, _ := provisioner.Config.JustAttributes()
 	var command, interpreter, environment hclwrite.Tokens
@@ -2752,7 +2771,8 @@ See https://www.pulumi.com/docs/iac/concepts/options/deletebeforereplace/ for de
 
 	// Add "command:Command" resources to handle provisioners
 	for idx, provisioner := range managedResource.Managed.Provisioners {
-		convertProvisioner(state, info, scopes, provisioner, pulumiName, idx, managedResource.ForEach, target)
+		convertProvisioner(state, info, scopes, provisioner,
+			pulumiName, path, idx, managedResource.ForEach, target)
 	}
 }
 

--- a/pkg/convert/tf_scopes.go
+++ b/pkg/convert/tf_scopes.go
@@ -65,6 +65,13 @@ type scopes struct {
 	eachKey    hcl.Traversal
 	eachValue  hcl.Traversal
 
+	// Set non-nil inside a provisioner block to the Pulumi-renamed traversal
+	// of the resource the provisioner is attached to, so that "self.X" resolves.
+	// selfPath is the fully qualified TF path of that resource (e.g. "aws_instance.web"),
+	// used for schema-aware attribute renaming on traversals rooted at "self".
+	self     hcl.Traversal
+	selfPath string
+
 	scope *lang.Scope
 
 	// loader is used to load Pulumi provider schemas, enabling checks like

--- a/pkg/testing/conformance/harness.go
+++ b/pkg/testing/conformance/harness.go
@@ -107,6 +107,7 @@ func AssertConversion(t *testing.T, tc TestCase) {
 	go func() {
 		defer wg.Done()
 		driver := tfexec.NewDriver(t, tfProviders)
+		driver.Env = map[string]string{"PULUMI_CONVERTER_CONFORMANCE_KIND": "tf"}
 		tfOutputs = driver.Apply(t, tc.Input, tc.Config)
 	}()
 
@@ -122,7 +123,8 @@ func AssertConversion(t *testing.T, tc TestCase) {
 		if !assert.NoError(t, err) {
 			return
 		}
-		pulumiResult = pulexec.Run(t, bridgedProviders, pclFiles, tc.Config)
+		pulumiResult = pulexec.Run(t, bridgedProviders, pclFiles, tc.Config,
+			map[string]string{"PULUMI_CONVERTER_CONFORMANCE_KIND": "pulumi"})
 	}()
 
 	wg.Wait()

--- a/pkg/testing/pulexec/run.go
+++ b/pkg/testing/pulexec/run.go
@@ -80,14 +80,23 @@ type Result struct {
 // Config values are set on the stack before deployment.
 //
 // programFiles maps relative paths to file contents (e.g. {"main.pp": "...", "mod/main.pp": "..."}).
-func Run(t *testing.T, provs []Provider, programFiles map[string]string, config map[string]string) Result {
+//
+// env is passed through to the pulumi CLI subprocess, which propagates it to language and
+// resource provider plugins (including command:local:Command's shell).
+func Run(
+	t *testing.T, provs []Provider, programFiles map[string]string,
+	config map[string]string, env map[string]string,
+) Result {
 	t.Helper()
 
 	binDir := ensurePCLLanguagePlugin(t)
 
 	dir := t.TempDir()
 
-	pulumiYAML := `name: test
+	// The project name is used as the default namespace for user config. It
+	// must not collide with any attached provider name, or user config like
+	// "<project>:foo" would be misrouted to the provider.
+	pulumiYAML := `name: conformance
 runtime: pcl
 backend:
   url: file://` + filepath.Join(dir, "state") + "\n"
@@ -101,12 +110,16 @@ backend:
 		require.NoError(t, os.WriteFile(fullPath, []byte(content), 0o600))
 	}
 
-	opts := append(make([]opttest.Option, 0, 4+len(provs)),
+	opts := append(make([]opttest.Option, 0, 4+len(env)+len(provs)),
 		opttest.Env("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "true"),
 		opttest.Env("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH")),
 		opttest.TestInPlace(),
 		opttest.SkipInstall(),
 	)
+
+	for k, v := range env {
+		opts = append(opts, opttest.Env(k, v))
+	}
 
 	for _, p := range provs {
 		info := p.Info

--- a/pkg/testing/pulexec/run_test.go
+++ b/pkg/testing/pulexec/run_test.go
@@ -74,7 +74,7 @@ output "computedValue" {
 }
 `
 
-	outputs := Run(t, []Provider{{Name: "test", Info: provider}}, map[string]string{"main.pp": program}, nil)
+	outputs := Run(t, []Provider{{Name: "test", Info: provider}}, map[string]string{"main.pp": program}, nil, nil)
 
 	require.Equal(t, map[string]string{
 		"value":         "hello",

--- a/pkg/testing/tfexec/driver.go
+++ b/pkg/testing/tfexec/driver.go
@@ -44,6 +44,9 @@ type Provider struct {
 type Driver struct {
 	cwd             string
 	reattachConfigs map[string]*plugin.ReattachConfig
+	// Env is passed through to the terraform subprocess (and therefore to any
+	// provisioner shell commands) on top of os.Environ().
+	Env map[string]string
 }
 
 func init() {

--- a/pkg/testing/tfexec/exec.go
+++ b/pkg/testing/tfexec/exec.go
@@ -32,6 +32,9 @@ func (d *Driver) execTf(t *testing.T, args ...string) ([]byte, error) {
 	if reattach := d.formatReattachEnvVar(); reattach != "" {
 		cmd.Env = append(cmd.Env, reattach)
 	}
+	for k, v := range d.Env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
 	t.Logf("%s", cmd.String())
 	err := cmd.Run()
 	if err != nil {

--- a/tests/conformance/l2_local_exec_provisioner_test.go
+++ b/tests/conformance/l2_local_exec_provisioner_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/pulumi/pulumi-converter-terraform/pkg/testing/conformance"
+	"github.com/pulumi/pulumi-converter-terraform/tests/conformance/providers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var installPulumiCommandPlugin = func(t *testing.T) {
+	var err error
+	var once sync.Once
+	once.Do(func() {
+		cmd := exec.CommandContext(t.Context(), "pulumi", "plugin", "install", "resource", "command")
+		err = cmd.Run()
+	})
+	require.NoError(t, err)
+}
+
+// TestL2LocalExecProvisioner verifies that a local-exec provisioner referencing
+// "self.X" on its parent resource is correctly converted and runs end to end.
+//
+// Each path writes to a filename derived from $PULUMI_CONVERTER_CONFORMANCE_KIND
+// (set to "tf" and "pulumi" by the harness) so the TF and Pulumi runs do not race
+// on a shared output file.
+func TestL2LocalExecProvisioner(t *testing.T) {
+	t.Parallel()
+
+	installPulumiCommandPlugin(t)
+
+	outDir := t.TempDir()
+
+	conformance.AssertConversion(t, conformance.TestCase{
+		Providers: []conformance.Provider{
+			{Name: "test", Factory: providers.TestProvider},
+		},
+		Config: map[string]string{"output_path": outDir},
+		Input: map[string]string{"main.tf": `
+variable "output_path" {
+  type = string
+}
+
+resource "test_resource" "example" {
+  value = "hello"
+
+  provisioner "local-exec" {
+    command = "printf %s \"${self.computed_value}\" > \"${var.output_path}/$PULUMI_CONVERTER_CONFORMANCE_KIND.txt\""
+  }
+}
+
+output "value" {
+  value = test_resource.example.value
+}
+`},
+	})
+
+	for _, kind := range []string{"tf", "pulumi"} {
+		got, err := os.ReadFile(filepath.Join(outDir, kind+".txt"))
+		require.NoError(t, err, "reading %s output", kind)
+		assert.Equal(t, "computed_hello", string(got), "%s provisioner output", kind)
+	}
+}

--- a/tests/conformance/testdata/TestL2LocalExecProvisioner/main.pp
+++ b/tests/conformance/testdata/TestL2LocalExecProvisioner/main.pp
@@ -1,0 +1,16 @@
+config "outputPath" "string" {
+}
+
+resource "example" "test:index/resource:Resource" {
+  value = "hello"
+}
+resource "exampleProvisioner0" "command:local:Command" {
+  options {
+    dependsOn = [example]
+  }
+  create = "printf %s \"${example.computedValue}\" > \"${outputPath}/$PULUMI_CONVERTER_CONFORMANCE_KIND.txt\""
+}
+
+output "value" {
+  value = example.value
+}


### PR DESCRIPTION
Respect when the `local-exec` provisioner references `self`, and add a conformance test for converting `local-exec` to the command provider.