### PR TITLE
Implement `provisioner "file"`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -21,6 +21,12 @@
   Command/CopyToRemote.
   [#430](https://github.com/pulumi/pulumi-converter-terraform/issues/430)
 
+- Convert `file` provisioners to `command:remote:CopyToRemote`. The `source` form
+  emits `fileAsset(...)` or `fileArchive(...)` when the path can be resolved at convert
+  time, falling back to `try(fileAsset(p), fileArchive(p))` for non-literal paths so
+  Pulumi picks the correct asset shape at runtime. The `content` form emits
+  `stringAsset(...)`.
+
 ### Bug Fixes
 
 - Fix dynamic blocks with list-typed `for_each` incorrectly wrapping the collection in `entries()`.

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,9 @@
 ### Improvements
 
+- Convert `file` provisioners to `command:remote:CopyToRemote`. The `source` form
+  emits `fileAsset(...)` or `fileArchive(...)` when the path can be resolved at convert
+  time, falling back to `try(fileAsset(p), fileArchive(p))` for non-literal paths so
+  Pulumi picks the correct asset shape at runtime. The `content` form emits
+  `stringAsset(...)`.
+
 ### Bug Fixes

--- a/pkg/convert/testdata/programs/file_provisioners/main.tf
+++ b/pkg/convert/testdata/programs/file_provisioners/main.tf
@@ -1,0 +1,36 @@
+# Test for `file` provisioner conversion. Covers source/content forms and
+# verifies that a connection-level `timeout` is propagated as a `customTimeouts`
+# option on the generated CopyToRemote resource — both when the connection
+# lives on the parent resource and when it is overridden on the provisioner
+# itself.
+
+resource "simple_resource" "file_resource" {
+  input_one = "hello"
+  input_two = true
+
+  connection {
+    host        = "primary.example.com"
+    user        = "deploy"
+    private_key = "resource-key"
+    timeout     = "30s"
+  }
+
+  # Inherits the resource-level connection (and its 30s timeout).
+  provisioner "file" {
+    content     = "from inline content\n"
+    destination = "/tmp/file-provisioner-content.txt"
+  }
+
+  # Overrides the resource-level connection with one that has its own,
+  # longer timeout. The override should also override the timeout.
+  provisioner "file" {
+    connection {
+      host        = "secondary.example.com"
+      user        = "deploy"
+      private_key = "override-key"
+      timeout     = "2m"
+    }
+    source      = "./payload.txt"
+    destination = "/tmp/file-provisioner-source.txt"
+  }
+}

--- a/pkg/convert/testdata/programs/file_provisioners/pcl/main.pp
+++ b/pkg/convert/testdata/programs/file_provisioners/pcl/main.pp
@@ -1,0 +1,43 @@
+# Test for `file` provisioner conversion. Covers source/content forms and
+# verifies that a connection-level `timeout` is propagated as a `customTimeouts`
+# option on the generated CopyToRemote resource — both when the connection
+# lives on the parent resource and when it is overridden on the provisioner
+# itself.
+resource "fileResource" "simple:index:resource" {
+  __logicalName = "file_resource"
+  inputOne      = "hello"
+  inputTwo      = true
+
+}
+resource "fileResourceProvisioner0" "command:remote:CopyToRemote" {
+  options {
+    dependsOn = [fileResource]
+    customTimeouts = {
+      create = "30s"
+      update = "30s"
+    }
+  }
+  connection = {
+    host       = "primary.example.com"
+    privateKey = "resource-key"
+    user       = "deploy"
+  }
+  source     = stringAsset("from inline content\n")
+  remotePath = "/tmp/file-provisioner-content.txt"
+}
+resource "fileResourceProvisioner1" "command:remote:CopyToRemote" {
+  options {
+    dependsOn = [fileResourceProvisioner0]
+    customTimeouts = {
+      create = "2m"
+      update = "2m"
+    }
+  }
+  connection = {
+    host       = "secondary.example.com"
+    privateKey = "override-key"
+    user       = "deploy"
+  }
+  source     = try(fileAsset("./payload.txt"), fileArchive("./payload.txt"))
+  remotePath = "/tmp/file-provisioner-source.txt"
+}

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -896,6 +896,13 @@ type convertState struct {
 	typeRenames pclOverlapRenames
 
 	sandboxedModuleNames map[string]string
+
+	// sourceFS and sourceDirectory let the converter inspect on-disk paths
+	// referenced by the input HCL (e.g. to decide between fileAsset and
+	// fileArchive for a literal path). Both are optional — when sourceFS is
+	// nil, callers fall back to dynamic forms.
+	sourceFS        afero.Fs
+	sourceDirectory string
 }
 
 type pclOverlapRenames struct {
@@ -2558,12 +2565,16 @@ func convertProvisioner(
 		convertRemoteExecProvisioner(state, scopes, provisioner,
 			resourceConnectionTokens, resourceConnectionTimeout,
 			resourceName, resourcePath, provisionerIndex, forEach, target)
+	case "file":
+		convertFileProvisioner(state, scopes, provisioner,
+			resourceConnectionTokens, resourceConnectionTimeout,
+			resourceName, resourcePath, provisionerIndex, forEach, target)
 	default:
 		state.appendDiagnostic(&hcl.Diagnostic{
 			Severity: hcl.DiagWarning,
 			Summary:  "Unsupported provisioner type",
 			Detail: fmt.Sprintf("Provisioner type %q is not supported by the converter; "+
-				"only \"local-exec\" and \"remote-exec\" are translated.", provisioner.Type),
+				"only \"local-exec\", \"remote-exec\", and \"file\" are translated.", provisioner.Type),
 			Subject: provisioner.DeclRange.Ptr(),
 		})
 		target.AppendUnstructuredTokens(hclwrite.Tokens{
@@ -3154,6 +3165,159 @@ func buildScriptsForExpr(
 	return tokens
 }
 
+// fileAssetOrArchiveExpr returns PCL tokens for the source asset of a Terraform
+// `file` provisioner. CopyToRemote.source can be a fileAsset (file) or
+// fileArchive (directory); Terraform doesn't expose this distinction in HCL, so
+// we resolve it like this:
+//
+//   - Literal path that exists on disk: stat it once at convert time and emit
+//     fileAsset or fileArchive directly.
+//   - Anything else (variable references, interpolations, paths that don't
+//     resolve at convert time): emit `try(fileAsset(p), fileArchive(p))` so
+//     Pulumi picks the correct form at runtime.
+func fileAssetOrArchiveExpr(
+	state *convertState, scopes *scopes, sourceExpr hcl.Expression,
+) hclwrite.Tokens {
+	pathTokens := convertExpression(state, true, scopes, "", sourceExpr)
+
+	if syn, ok := sourceExpr.(hclsyntax.Expression); ok {
+		if literal, isIdent := matchStaticString(syn); literal != nil && !isIdent {
+			fullPath := filepath.Join(state.sourceDirectory, *literal)
+			if info, err := state.sourceFS.Stat(fullPath); err == nil {
+				if info.IsDir() {
+					return hclwrite.TokensForFunctionCall("fileArchive", pathTokens)
+				}
+				return hclwrite.TokensForFunctionCall("fileAsset", pathTokens)
+			}
+		}
+	}
+
+	return hclwrite.TokensForFunctionCall("try",
+		hclwrite.TokensForFunctionCall("fileAsset", pathTokens),
+		hclwrite.TokensForFunctionCall("fileArchive", pathTokens),
+	)
+}
+
+// convertFileProvisioner translates a Terraform `file` provisioner into a single
+// command:remote:CopyToRemote resource. The provisioner copies a local file or
+// directory (`source`) or inline string (`content`) to a path on the remote
+// (`destination`).
+func convertFileProvisioner(
+	state *convertState,
+	scopes *scopes,
+	provisioner *configs.Provisioner,
+	resourceConnectionTokens, resourceConnectionTimeout hclwrite.Tokens,
+	resourceName string, resourcePath string, provisionerIndex int,
+	forEach hcl.Expression,
+	target *hclwrite.Body,
+) {
+	if provisioner.When == configs.ProvisionerWhenDestroy {
+		state.appendDiagnostic(&hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "file provisioner with when=destroy is not supported",
+			Detail: "The file provisioner only runs at create-time in Terraform; " +
+				"`when = destroy` is rejected by Terraform itself, so the converter does not translate it.",
+			Subject: provisioner.DeclRange.Ptr(),
+		})
+		return
+	}
+
+	scopes.self = hcl.Traversal{hcl.TraverseRoot{Name: resourceName}}
+	scopes.selfPath = resourcePath
+	defer func() { scopes.self, scopes.selfPath = nil, "" }()
+
+	var connectionTokens, timeoutTokens hclwrite.Tokens
+	if provisioner.Connection != nil {
+		connectionTokens, timeoutTokens = convertConnection(state, scopes, provisioner.Connection)
+	} else {
+		connectionTokens, timeoutTokens = resourceConnectionTokens, resourceConnectionTimeout
+	}
+	if connectionTokens == nil {
+		state.appendDiagnostic(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "file provisioner is missing a connection block",
+			Detail: "the file provisioner requires a connection block on the provisioner or the parent resource " +
+				"specifying at least the host to connect to.",
+			Subject: provisioner.DeclRange.Ptr(),
+		})
+		return
+	}
+
+	attrs, _ := provisioner.Config.JustAttributes()
+	var sourceExpr, contentExpr, destinationExpr hcl.Expression
+	for _, attr := range attrs {
+		switch attr.Name {
+		case "source":
+			sourceExpr = attr.Expr
+		case "content":
+			contentExpr = attr.Expr
+		case "destination":
+			destinationExpr = attr.Expr
+		default:
+			state.appendDiagnostic(&hcl.Diagnostic{
+				Severity: hcl.DiagWarning,
+				Summary:  "Unrecognized file provisioner attribute",
+				Detail: fmt.Sprintf("Attribute %q on a file provisioner is not recognized "+
+					"and was not translated.", attr.Name),
+				Subject: attr.Range.Ptr(),
+			})
+		}
+	}
+
+	if destinationExpr == nil {
+		state.appendDiagnostic(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "file provisioner is missing destination",
+			Detail:   "file provisioner requires a `destination` attribute.",
+			Subject:  provisioner.DeclRange.Ptr(),
+		})
+		return
+	}
+	if sourceExpr == nil && contentExpr == nil {
+		state.appendDiagnostic(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "file provisioner has no source",
+			Detail:   "file provisioner requires exactly one of `source` or `content`.",
+			Subject:  provisioner.DeclRange.Ptr(),
+		})
+		return
+	}
+	if sourceExpr != nil && contentExpr != nil {
+		state.appendDiagnostic(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "file provisioner has both source and content",
+			Detail:   "file provisioner must specify exactly one of `source` or `content`.",
+			Subject:  provisioner.DeclRange.Ptr(),
+		})
+		return
+	}
+
+	provisionerName := fmt.Sprintf("%sProvisioner%d", resourceName, provisionerIndex)
+
+	block := hclwrite.NewBlock("resource", []string{provisionerName, "command:remote:CopyToRemote"})
+	body := block.Body()
+	options := body.AppendNewBlock("options", nil).Body()
+	setForEachRange(state, scopes, options, forEach)
+	options.SetAttributeRaw("dependsOn", provisionerDependsOn(resourceName, provisionerIndex, forEach))
+	if ct := customTimeoutsTokens(timeoutTokens, timeoutTokens); ct != nil {
+		options.SetAttributeRaw("customTimeouts", ct)
+	}
+
+	body.SetAttributeRaw("connection", connectionTokens)
+
+	var sourceTokens hclwrite.Tokens
+	if sourceExpr != nil {
+		sourceTokens = fileAssetOrArchiveExpr(state, scopes, sourceExpr)
+	} else {
+		contentTokens := convertExpression(state, true, scopes, "", contentExpr)
+		sourceTokens = hclwrite.TokensForFunctionCall("stringAsset", contentTokens)
+	}
+	body.SetAttributeRaw("source", sourceTokens)
+	body.SetAttributeRaw("remotePath", convertExpression(state, true, scopes, "", destinationExpr))
+
+	target.AppendBlock(block)
+}
+
 func convertManagedResources(state *convertState,
 	info ProviderInfoSource, scopes *scopes,
 	managedResource *configs.Resource,
@@ -3711,6 +3875,8 @@ func translateModuleSourceCode(
 			nameToRename: make(map[string]string),
 			renameToName: make(map[string]string),
 		},
+		sourceFS:        sourceRoot,
+		sourceDirectory: sourceDirectory,
 	}
 
 	// First go through and add everything to the items list so we can sort it by source order

--- a/tests/conformance/l2_file_provisioner_test.go
+++ b/tests/conformance/l2_file_provisioner_test.go
@@ -1,0 +1,514 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-converter-terraform/pkg/testing/conformance"
+	"github.com/pulumi/pulumi-converter-terraform/pkg/testing/sshcontainer"
+	"github.com/pulumi/pulumi-converter-terraform/tests/conformance/providers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestL2FileProvisionerSourceFile verifies that a `file` provisioner whose
+// `source` is a literal path resolving to an on-disk file converts to a
+// CopyToRemote with `source = fileAsset(...)` and copies the file to the
+// remote.
+func TestL2FileProvisionerSourceFile(t *testing.T) {
+	t.Parallel()
+	installPulumiCommandPlugin(t)
+
+	ssh := sshcontainer.Start(t)
+
+	_, err := ssh.Exec("mkdir -p /tmp/conformance")
+	require.NoError(t, err, "pre-creating remote dir")
+
+	conformance.AssertConversion(t, conformance.TestCase{
+		Providers: []conformance.Provider{
+			{Name: "test", Factory: providers.TestProvider},
+		},
+		Config: remoteExecConfig(ssh),
+		Input: map[string]string{
+			"main.tf": remoteExecConnectionVars + `
+resource "test_resource" "example" {
+  value = "hello"
+
+  provisioner "file" {
+    connection {
+      host        = var.ssh_host
+      port        = var.ssh_port
+      user        = var.ssh_user
+      private_key = var.ssh_private_key
+    }
+    source      = "./hello.txt"
+    destination = "/tmp/conformance/source-file-${var.conformance_kind}.txt"
+  }
+}
+
+output "value" {
+  value = test_resource.example.value
+}
+`,
+			"hello.txt": "hello from file provisioner\n",
+		},
+	})
+
+	for _, kind := range []string{"tf", "pulumi"} {
+		out, err := ssh.Exec("cat /tmp/conformance/source-file-" + kind + ".txt")
+		require.NoError(t, err, "reading %s remote file", kind)
+		assert.Equal(t, "hello from file provisioner\n", out, "%s file contents", kind)
+	}
+}
+
+// TestL2FileProvisionerSourceDirNoTrailingSlash verifies that a `file`
+// provisioner whose `source` is a literal directory path *without* a trailing
+// slash converts to `source = fileArchive(...)` and that the directory itself
+// is copied under the destination on the remote (matching Terraform semantics).
+func TestL2FileProvisionerSourceDirNoTrailingSlash(t *testing.T) {
+	t.Parallel()
+	installPulumiCommandPlugin(t)
+
+	ssh := sshcontainer.Start(t)
+
+	// Pre-create the destination directories on the remote so the test can focus
+	// purely on the `file` provisioner's behavior.
+	for _, kind := range []string{"tf", "pulumi"} {
+		_, err := ssh.Exec("mkdir -p /tmp/conformance/dir-no-slash-" + kind)
+		require.NoError(t, err, "pre-creating %s remote dir", kind)
+	}
+
+	conformance.AssertConversion(t, conformance.TestCase{
+		Providers: []conformance.Provider{
+			{Name: "test", Factory: providers.TestProvider},
+		},
+		Config: remoteExecConfig(ssh),
+		Input: map[string]string{
+			"main.tf": remoteExecConnectionVars + `
+resource "test_resource" "example" {
+  value = "hello"
+
+  provisioner "file" {
+    connection {
+      host        = var.ssh_host
+      port        = var.ssh_port
+      user        = var.ssh_user
+      private_key = var.ssh_private_key
+    }
+    source      = "./payload"
+    destination = "/tmp/conformance/dir-no-slash-${var.conformance_kind}"
+  }
+}
+
+output "value" {
+  value = test_resource.example.value
+}
+`,
+			"payload/a.txt": "alpha\n",
+			"payload/b.txt": "bravo\n",
+		},
+	})
+
+	// Without a trailing slash on source, Terraform copies the directory itself
+	// under the destination, so the files end up at <destination>/payload/<file>.
+	for _, kind := range []string{"tf", "pulumi"} {
+		out, err := ssh.Exec("cat /tmp/conformance/dir-no-slash-" + kind + "/payload/a.txt")
+		require.NoError(t, err, "%s a.txt", kind)
+		assert.Equal(t, "alpha\n", out)
+
+		out, err = ssh.Exec("cat /tmp/conformance/dir-no-slash-" + kind + "/payload/b.txt")
+		require.NoError(t, err, "%s b.txt", kind)
+		assert.Equal(t, "bravo\n", out)
+	}
+}
+
+// TestL2FileProvisionerSourceDirTrailingSlash verifies that a `file`
+// provisioner whose `source` is a literal directory path *with* a trailing
+// slash converts to `source = fileArchive(...)` and that just the *contents*
+// land at the destination (matching Terraform semantics).
+func TestL2FileProvisionerSourceDirTrailingSlash(t *testing.T) {
+	t.Parallel()
+	installPulumiCommandPlugin(t)
+
+	ssh := sshcontainer.Start(t)
+
+	for _, kind := range []string{"tf", "pulumi"} {
+		_, err := ssh.Exec("mkdir -p /tmp/conformance/dir-slash-" + kind)
+		require.NoError(t, err, "pre-creating %s remote dir", kind)
+	}
+
+	conformance.AssertConversion(t, conformance.TestCase{
+		Providers: []conformance.Provider{
+			{Name: "test", Factory: providers.TestProvider},
+		},
+		Config: remoteExecConfig(ssh),
+		Input: map[string]string{
+			"main.tf": remoteExecConnectionVars + `
+resource "test_resource" "example" {
+  value = "hello"
+
+  provisioner "file" {
+    connection {
+      host        = var.ssh_host
+      port        = var.ssh_port
+      user        = var.ssh_user
+      private_key = var.ssh_private_key
+    }
+    source      = "./payload/"
+    destination = "/tmp/conformance/dir-slash-${var.conformance_kind}"
+  }
+}
+
+output "value" {
+  value = test_resource.example.value
+}
+`,
+			"payload/a.txt": "alpha\n",
+			"payload/b.txt": "bravo\n",
+		},
+	})
+
+	// With a trailing slash on source, Terraform copies the *contents* of the
+	// directory to the destination, so the files end up directly at
+	// <destination>/<file>.
+	for _, kind := range []string{"tf", "pulumi"} {
+		out, err := ssh.Exec("cat /tmp/conformance/dir-slash-" + kind + "/a.txt")
+		require.NoError(t, err, "%s a.txt", kind)
+		assert.Equal(t, "alpha\n", out)
+
+		out, err = ssh.Exec("cat /tmp/conformance/dir-slash-" + kind + "/b.txt")
+		require.NoError(t, err, "%s b.txt", kind)
+		assert.Equal(t, "bravo\n", out)
+	}
+}
+
+// TestL2FileProvisionerContent verifies that a `file` provisioner using the
+// `content` form converts to `source = stringAsset(...)` and writes the inline
+// content to the destination on the remote.
+func TestL2FileProvisionerContent(t *testing.T) {
+	t.Parallel()
+	installPulumiCommandPlugin(t)
+
+	ssh := sshcontainer.Start(t)
+
+	_, err := ssh.Exec("mkdir -p /tmp/conformance")
+	require.NoError(t, err, "pre-creating remote dir")
+
+	conformance.AssertConversion(t, conformance.TestCase{
+		Providers: []conformance.Provider{
+			{Name: "test", Factory: providers.TestProvider},
+		},
+		Config: remoteExecConfig(ssh),
+		Input: map[string]string{
+			"main.tf": remoteExecConnectionVars + `
+resource "test_resource" "example" {
+  value = "hello"
+
+  provisioner "file" {
+    connection {
+      host        = var.ssh_host
+      port        = var.ssh_port
+      user        = var.ssh_user
+      private_key = var.ssh_private_key
+    }
+    content     = "inline content for ${var.conformance_kind}\n"
+    destination = "/tmp/conformance/content-${var.conformance_kind}.txt"
+  }
+}
+
+output "value" {
+  value = test_resource.example.value
+}
+`,
+		},
+	})
+
+	for _, kind := range []string{"tf", "pulumi"} {
+		out, err := ssh.Exec("cat /tmp/conformance/content-" + kind + ".txt")
+		require.NoError(t, err, "%s content file", kind)
+		assert.Equal(t, "inline content for "+kind+"\n", out)
+	}
+}
+
+// TestL2FileProvisionerResourceConnection verifies that a `file` provisioner
+// inherits a `connection` block defined on the parent resource when the
+// provisioner itself does not declare one.
+func TestL2FileProvisionerResourceConnection(t *testing.T) {
+	t.Parallel()
+	installPulumiCommandPlugin(t)
+
+	ssh := sshcontainer.Start(t)
+
+	_, err := ssh.Exec("mkdir -p /tmp/conformance")
+	require.NoError(t, err, "pre-creating remote dir")
+
+	conformance.AssertConversion(t, conformance.TestCase{
+		Providers: []conformance.Provider{
+			{Name: "test", Factory: providers.TestProvider},
+		},
+		Config: remoteExecConfig(ssh),
+		Input: map[string]string{
+			"main.tf": remoteExecConnectionVars + `
+resource "test_resource" "example" {
+  value = "hello"
+
+  connection {
+    host        = var.ssh_host
+    port        = var.ssh_port
+    user        = var.ssh_user
+    private_key = var.ssh_private_key
+  }
+
+  provisioner "file" {
+    content     = "from resource conn ${var.conformance_kind}\n"
+    destination = "/tmp/conformance/resource-conn-${var.conformance_kind}.txt"
+  }
+}
+
+output "value" {
+  value = test_resource.example.value
+}
+`,
+		},
+	})
+
+	for _, kind := range []string{"tf", "pulumi"} {
+		out, err := ssh.Exec("cat /tmp/conformance/resource-conn-" + kind + ".txt")
+		require.NoError(t, err, "%s file", kind)
+		assert.Equal(t, "from resource conn "+kind+"\n", out)
+	}
+}
+
+// TestL2FileProvisionerMultiple verifies that multiple `file` provisioners on a
+// single resource convert to a chain of CopyToRemote resources where each
+// depends on the previous (and the first depends on the parent resource), so
+// they execute in the order Terraform would run them.
+func TestL2FileProvisionerMultiple(t *testing.T) {
+	t.Parallel()
+	installPulumiCommandPlugin(t)
+
+	ssh := sshcontainer.Start(t)
+
+	_, err := ssh.Exec("mkdir -p /tmp/conformance")
+	require.NoError(t, err, "pre-creating remote dir")
+
+	conformance.AssertConversion(t, conformance.TestCase{
+		Providers: []conformance.Provider{
+			{Name: "test", Factory: providers.TestProvider},
+		},
+		Config: remoteExecConfig(ssh),
+		Input: map[string]string{
+			"main.tf": remoteExecConnectionVars + `
+resource "test_resource" "example" {
+  value = "hello"
+
+  connection {
+    host        = var.ssh_host
+    port        = var.ssh_port
+    user        = var.ssh_user
+    private_key = var.ssh_private_key
+  }
+
+  provisioner "file" {
+    content     = "first ${var.conformance_kind}\n"
+    destination = "/tmp/conformance/multi-first-${var.conformance_kind}.txt"
+  }
+
+  provisioner "file" {
+    content     = "second ${var.conformance_kind}\n"
+    destination = "/tmp/conformance/multi-second-${var.conformance_kind}.txt"
+  }
+}
+
+output "value" {
+  value = test_resource.example.value
+}
+`,
+		},
+	})
+
+	for _, kind := range []string{"tf", "pulumi"} {
+		out, err := ssh.Exec("cat /tmp/conformance/multi-first-" + kind + ".txt")
+		require.NoError(t, err, "%s first", kind)
+		assert.Equal(t, "first "+kind+"\n", out)
+
+		out, err = ssh.Exec("cat /tmp/conformance/multi-second-" + kind + ".txt")
+		require.NoError(t, err, "%s second", kind)
+		assert.Equal(t, "second "+kind+"\n", out)
+	}
+}
+
+// TestL2FileProvisionerProvisionerConnectionOverridesResource verifies that
+// when both the resource and the provisioner declare a `connection` block, the
+// provisioner-level connection wins. The resource-level block points at a host
+// that is guaranteed not to resolve, so if the converter ever loses the
+// override the Pulumi run would fail to connect.
+func TestL2FileProvisionerProvisionerConnectionOverridesResource(t *testing.T) {
+	t.Parallel()
+	installPulumiCommandPlugin(t)
+
+	ssh := sshcontainer.Start(t)
+
+	_, err := ssh.Exec("mkdir -p /tmp/conformance")
+	require.NoError(t, err, "pre-creating remote dir")
+
+	conformance.AssertConversion(t, conformance.TestCase{
+		Providers: []conformance.Provider{
+			{Name: "test", Factory: providers.TestProvider},
+		},
+		Config: remoteExecConfig(ssh),
+		Input: map[string]string{
+			"main.tf": remoteExecConnectionVars + `
+resource "test_resource" "example" {
+  value = "hello"
+
+  # Bogus resource-level connection. If the converter mistakenly used this
+  # instead of the provisioner-level override, the Pulumi run would fail to
+  # connect.
+  connection {
+    host        = "invalid.example.invalid"
+    port        = 1
+    user        = "nobody"
+    private_key = "ignored"
+  }
+
+  provisioner "file" {
+    connection {
+      host        = var.ssh_host
+      port        = var.ssh_port
+      user        = var.ssh_user
+      private_key = var.ssh_private_key
+    }
+    content     = "override ${var.conformance_kind}\n"
+    destination = "/tmp/conformance/override-${var.conformance_kind}.txt"
+  }
+}
+
+output "value" {
+  value = test_resource.example.value
+}
+`,
+		},
+	})
+
+	for _, kind := range []string{"tf", "pulumi"} {
+		out, err := ssh.Exec("cat /tmp/conformance/override-" + kind + ".txt")
+		require.NoError(t, err, "%s file", kind)
+		assert.Equal(t, "override "+kind+"\n", out)
+	}
+}
+
+// TestL2FileProvisionerSourceDynamic verifies that a `file` provisioner whose
+// `source` is a non-literal expression (cannot be statically resolved at
+// convert time) converts to `source = try(fileAsset(p), fileArchive(p))` —
+// letting Pulumi pick the correct asset shape at runtime. Two sub-tests
+// exercise both runtime branches of the `try`: one where the variable resolves
+// to a file (fileAsset succeeds) and one where it resolves to a directory
+// (fileAsset fails, fileArchive succeeds).
+func TestL2FileProvisionerSourceDynamic(t *testing.T) {
+	t.Parallel()
+	installPulumiCommandPlugin(t)
+
+	const tfProgram = `
+variable "src_path" {
+  type = string
+}
+
+resource "test_resource" "example" {
+  value = "hello"
+
+  provisioner "file" {
+    connection {
+      host        = var.ssh_host
+      port        = var.ssh_port
+      user        = var.ssh_user
+      private_key = var.ssh_private_key
+    }
+    source      = var.src_path
+    destination = "/tmp/conformance/dynamic-${var.conformance_kind}"
+  }
+}
+
+output "value" {
+  value = test_resource.example.value
+}
+`
+
+	t.Run("file", func(t *testing.T) {
+		t.Parallel()
+
+		ssh := sshcontainer.Start(t)
+
+		_, err := ssh.Exec("mkdir -p /tmp/conformance")
+		require.NoError(t, err, "pre-creating remote dir")
+
+		cfg := remoteExecConfig(ssh)
+		cfg["src_path"] = "./hello.txt"
+
+		conformance.AssertConversion(t, conformance.TestCase{
+			Providers: []conformance.Provider{
+				{Name: "test", Factory: providers.TestProvider},
+			},
+			Config: cfg,
+			Input: map[string]string{
+				"main.tf":   remoteExecConnectionVars + tfProgram,
+				"hello.txt": "dynamic source\n",
+			},
+		})
+
+		for _, kind := range []string{"tf", "pulumi"} {
+			out, err := ssh.Exec("cat /tmp/conformance/dynamic-" + kind)
+			require.NoError(t, err, "%s dynamic file", kind)
+			assert.Equal(t, "dynamic source\n", out)
+		}
+	})
+
+	t.Run("dir", func(t *testing.T) {
+		t.Parallel()
+
+		ssh := sshcontainer.Start(t)
+
+		for _, kind := range []string{"tf", "pulumi"} {
+			_, err := ssh.Exec("mkdir -p /tmp/conformance/dynamic-" + kind)
+			require.NoError(t, err, "pre-creating %s remote dir", kind)
+		}
+
+		cfg := remoteExecConfig(ssh)
+		cfg["src_path"] = "./payload/"
+
+		conformance.AssertConversion(t, conformance.TestCase{
+			Providers: []conformance.Provider{
+				{Name: "test", Factory: providers.TestProvider},
+			},
+			Config: cfg,
+			Input: map[string]string{
+				"main.tf":       remoteExecConnectionVars + tfProgram,
+				"payload/a.txt": "alpha\n",
+				"payload/b.txt": "bravo\n",
+			},
+		})
+
+		for _, kind := range []string{"tf", "pulumi"} {
+			out, err := ssh.Exec("cat /tmp/conformance/dynamic-" + kind + "/a.txt")
+			require.NoError(t, err, "%s a.txt", kind)
+			assert.Equal(t, "alpha\n", out)
+
+			out, err = ssh.Exec("cat /tmp/conformance/dynamic-" + kind + "/b.txt")
+			require.NoError(t, err, "%s b.txt", kind)
+			assert.Equal(t, "bravo\n", out)
+		}
+	})
+}

--- a/tests/conformance/testdata/TestL2FileProvisionerContent/main.pp
+++ b/tests/conformance/testdata/TestL2FileProvisionerContent/main.pp
@@ -1,0 +1,35 @@
+config "conformanceKind" "string" {
+}
+
+config "sshHost" "string" {
+}
+
+config "sshPort" "number" {
+}
+
+config "sshUser" "string" {
+}
+
+config "sshPrivateKey" "string" {
+}
+
+resource "example" "test:index/resource:Resource" {
+  value = "hello"
+}
+resource "exampleProvisioner0" "command:remote:CopyToRemote" {
+  options {
+    dependsOn = [example]
+  }
+  connection = {
+    host       = sshHost
+    port       = sshPort
+    privateKey = sshPrivateKey
+    user       = sshUser
+  }
+  source     = stringAsset("inline content for ${conformanceKind}\n")
+  remotePath = "/tmp/conformance/content-${conformanceKind}.txt"
+}
+
+output "value" {
+  value = example.value
+}

--- a/tests/conformance/testdata/TestL2FileProvisionerMultiple/main.pp
+++ b/tests/conformance/testdata/TestL2FileProvisionerMultiple/main.pp
@@ -1,0 +1,48 @@
+config "conformanceKind" "string" {
+}
+
+config "sshHost" "string" {
+}
+
+config "sshPort" "number" {
+}
+
+config "sshUser" "string" {
+}
+
+config "sshPrivateKey" "string" {
+}
+
+resource "example" "test:index/resource:Resource" {
+  value = "hello"
+}
+resource "exampleProvisioner0" "command:remote:CopyToRemote" {
+  options {
+    dependsOn = [example]
+  }
+  connection = {
+    host       = sshHost
+    port       = sshPort
+    privateKey = sshPrivateKey
+    user       = sshUser
+  }
+  source     = stringAsset("first ${conformanceKind}\n")
+  remotePath = "/tmp/conformance/multi-first-${conformanceKind}.txt"
+}
+resource "exampleProvisioner1" "command:remote:CopyToRemote" {
+  options {
+    dependsOn = [exampleProvisioner0]
+  }
+  connection = {
+    host       = sshHost
+    port       = sshPort
+    privateKey = sshPrivateKey
+    user       = sshUser
+  }
+  source     = stringAsset("second ${conformanceKind}\n")
+  remotePath = "/tmp/conformance/multi-second-${conformanceKind}.txt"
+}
+
+output "value" {
+  value = example.value
+}

--- a/tests/conformance/testdata/TestL2FileProvisionerProvisionerConnectionOverridesResource/main.pp
+++ b/tests/conformance/testdata/TestL2FileProvisionerProvisionerConnectionOverridesResource/main.pp
@@ -1,0 +1,35 @@
+config "conformanceKind" "string" {
+}
+
+config "sshHost" "string" {
+}
+
+config "sshPort" "number" {
+}
+
+config "sshUser" "string" {
+}
+
+config "sshPrivateKey" "string" {
+}
+
+resource "example" "test:index/resource:Resource" {
+  value = "hello"
+}
+resource "exampleProvisioner0" "command:remote:CopyToRemote" {
+  options {
+    dependsOn = [example]
+  }
+  connection = {
+    host       = sshHost
+    port       = sshPort
+    privateKey = sshPrivateKey
+    user       = sshUser
+  }
+  source     = stringAsset("override ${conformanceKind}\n")
+  remotePath = "/tmp/conformance/override-${conformanceKind}.txt"
+}
+
+output "value" {
+  value = example.value
+}

--- a/tests/conformance/testdata/TestL2FileProvisionerResourceConnection/main.pp
+++ b/tests/conformance/testdata/TestL2FileProvisionerResourceConnection/main.pp
@@ -1,0 +1,35 @@
+config "conformanceKind" "string" {
+}
+
+config "sshHost" "string" {
+}
+
+config "sshPort" "number" {
+}
+
+config "sshUser" "string" {
+}
+
+config "sshPrivateKey" "string" {
+}
+
+resource "example" "test:index/resource:Resource" {
+  value = "hello"
+}
+resource "exampleProvisioner0" "command:remote:CopyToRemote" {
+  options {
+    dependsOn = [example]
+  }
+  connection = {
+    host       = sshHost
+    port       = sshPort
+    privateKey = sshPrivateKey
+    user       = sshUser
+  }
+  source     = stringAsset("from resource conn ${conformanceKind}\n")
+  remotePath = "/tmp/conformance/resource-conn-${conformanceKind}.txt"
+}
+
+output "value" {
+  value = example.value
+}

--- a/tests/conformance/testdata/TestL2FileProvisionerSourceDirNoTrailingSlash/main.pp
+++ b/tests/conformance/testdata/TestL2FileProvisionerSourceDirNoTrailingSlash/main.pp
@@ -1,0 +1,35 @@
+config "conformanceKind" "string" {
+}
+
+config "sshHost" "string" {
+}
+
+config "sshPort" "number" {
+}
+
+config "sshUser" "string" {
+}
+
+config "sshPrivateKey" "string" {
+}
+
+resource "example" "test:index/resource:Resource" {
+  value = "hello"
+}
+resource "exampleProvisioner0" "command:remote:CopyToRemote" {
+  options {
+    dependsOn = [example]
+  }
+  connection = {
+    host       = sshHost
+    port       = sshPort
+    privateKey = sshPrivateKey
+    user       = sshUser
+  }
+  source     = fileArchive("./payload")
+  remotePath = "/tmp/conformance/dir-no-slash-${conformanceKind}"
+}
+
+output "value" {
+  value = example.value
+}

--- a/tests/conformance/testdata/TestL2FileProvisionerSourceDirTrailingSlash/main.pp
+++ b/tests/conformance/testdata/TestL2FileProvisionerSourceDirTrailingSlash/main.pp
@@ -1,0 +1,35 @@
+config "conformanceKind" "string" {
+}
+
+config "sshHost" "string" {
+}
+
+config "sshPort" "number" {
+}
+
+config "sshUser" "string" {
+}
+
+config "sshPrivateKey" "string" {
+}
+
+resource "example" "test:index/resource:Resource" {
+  value = "hello"
+}
+resource "exampleProvisioner0" "command:remote:CopyToRemote" {
+  options {
+    dependsOn = [example]
+  }
+  connection = {
+    host       = sshHost
+    port       = sshPort
+    privateKey = sshPrivateKey
+    user       = sshUser
+  }
+  source     = fileArchive("./payload/")
+  remotePath = "/tmp/conformance/dir-slash-${conformanceKind}"
+}
+
+output "value" {
+  value = example.value
+}

--- a/tests/conformance/testdata/TestL2FileProvisionerSourceDynamic/dir/main.pp
+++ b/tests/conformance/testdata/TestL2FileProvisionerSourceDynamic/dir/main.pp
@@ -1,0 +1,38 @@
+config "conformanceKind" "string" {
+}
+
+config "sshHost" "string" {
+}
+
+config "sshPort" "number" {
+}
+
+config "sshUser" "string" {
+}
+
+config "sshPrivateKey" "string" {
+}
+
+config "srcPath" "string" {
+}
+
+resource "example" "test:index/resource:Resource" {
+  value = "hello"
+}
+resource "exampleProvisioner0" "command:remote:CopyToRemote" {
+  options {
+    dependsOn = [example]
+  }
+  connection = {
+    host       = sshHost
+    port       = sshPort
+    privateKey = sshPrivateKey
+    user       = sshUser
+  }
+  source     = try(fileAsset(srcPath), fileArchive(srcPath))
+  remotePath = "/tmp/conformance/dynamic-${conformanceKind}"
+}
+
+output "value" {
+  value = example.value
+}

--- a/tests/conformance/testdata/TestL2FileProvisionerSourceDynamic/file/main.pp
+++ b/tests/conformance/testdata/TestL2FileProvisionerSourceDynamic/file/main.pp
@@ -1,0 +1,38 @@
+config "conformanceKind" "string" {
+}
+
+config "sshHost" "string" {
+}
+
+config "sshPort" "number" {
+}
+
+config "sshUser" "string" {
+}
+
+config "sshPrivateKey" "string" {
+}
+
+config "srcPath" "string" {
+}
+
+resource "example" "test:index/resource:Resource" {
+  value = "hello"
+}
+resource "exampleProvisioner0" "command:remote:CopyToRemote" {
+  options {
+    dependsOn = [example]
+  }
+  connection = {
+    host       = sshHost
+    port       = sshPort
+    privateKey = sshPrivateKey
+    user       = sshUser
+  }
+  source     = try(fileAsset(srcPath), fileArchive(srcPath))
+  remotePath = "/tmp/conformance/dynamic-${conformanceKind}"
+}
+
+output "value" {
+  value = example.value
+}

--- a/tests/conformance/testdata/TestL2FileProvisionerSourceFile/main.pp
+++ b/tests/conformance/testdata/TestL2FileProvisionerSourceFile/main.pp
@@ -1,0 +1,35 @@
+config "conformanceKind" "string" {
+}
+
+config "sshHost" "string" {
+}
+
+config "sshPort" "number" {
+}
+
+config "sshUser" "string" {
+}
+
+config "sshPrivateKey" "string" {
+}
+
+resource "example" "test:index/resource:Resource" {
+  value = "hello"
+}
+resource "exampleProvisioner0" "command:remote:CopyToRemote" {
+  options {
+    dependsOn = [example]
+  }
+  connection = {
+    host       = sshHost
+    port       = sshPort
+    privateKey = sshPrivateKey
+    user       = sshUser
+  }
+  source     = fileAsset("./hello.txt")
+  remotePath = "/tmp/conformance/source-file-${conformanceKind}.txt"
+}
+
+output "value" {
+  value = example.value
+}


### PR DESCRIPTION
This PR adds conversion of file type provisioners by translating them into `command:remote:CopyToRemote` resources.

Fixes https://github.com/pulumi/pulumi-converter-terraform/issues/431