### PR TITLE
Run `make renovate` for every gomod update

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,7 +14,6 @@
     },
     {
       matchManagers: ['gomod'],
-      matchPackageNames: ['github.com/pulumi/pulumi/pkg/v3'],
       postUpgradeTasks: {
         // The org Renovate config only allowlists `make build` and
         // `make renovate`; the latter provisions Go via mise and runs sync-pcl.


### PR DESCRIPTION
With `executionMode: 'branch'`, Renovate reads `postUpgradeTasks` from the branch config, which is copied from a single arbitrary upgrade in the branch (the one with the largest `fileReplacePosition` — see renovatebot/renovate#42704). Scoping the rule to `pkg/v3` meant the task ran when `pkg/v3` was the only update in the branch (#461) but was silently skipped when it was grouped with other first-party updates (#466, #468), leaving `sdk/pcl` out of sync and failing the lint `sync-pcl` check.

Match every gomod dependency instead — this mirrors what pulumi/pulumi's renovate.json5 does — so whichever upgrade Renovate copies into the branch config carries the task. `make renovate` is idempotent, so extra triggers are harmless.

Validated with `renovate-config-validator`.