### PR TITLE
Pre-install external, null, and terraform-provider test plugins

### DIFF
--- a/.github/workflows/stage-test.yml
+++ b/.github/workflows/stage-test.yml
@@ -52,10 +52,13 @@ jobs:
         run: |
           pulumi plugin install resource aws
           pulumi plugin install resource azure
+          pulumi plugin install resource external
           pulumi plugin install resource gcp
           pulumi plugin install resource kubernetes
+          pulumi plugin install resource null
           pulumi plugin install resource random
           pulumi plugin install resource std
+          pulumi plugin install resource terraform-provider
 
       - name: Build and install
         run: make install


### PR DESCRIPTION
The terraform-aws-lambda example test needs the `external`, `null`, and `terraform-provider` resource plugins. They were not pre-installed, so the four per-language `pulumi convert` subprocesses raced to install them mid-test. A convert that observed a partially-unpacked plugin directory failed provider-info lookup and emitted a bare `external` token, which code generation rejected with:

```
error: package.pp:12,14-24: malformed token 'external': expected 'pkg:module:member' or 'pkg:member'
```

This flake was observed on #415 (typescript, run 30438037305) and on main's 2026-07-28 cron run (go, run 30344041466), each time preceded by:

```
Failed to get provider info for "external": ... loading PulumiPlugin.yaml: open /home/runner/.pulumi/plugins/resource-external-v0.2.1/PulumiPlugin.yaml: no such file or directory
```

Pre-installing the plugins removes the concurrent install race, matching the existing pre-install list.