### PR TITLE
Cache provider mappings for bulk example conversion

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,8 @@
 - Cache HCL syntax tokens per source file to reduce converter CPU use and
   allocations.
   [#490](https://github.com/pulumi/pulumi-converter-terraform/pull/490)
+- Cache provider mappings during bulk example conversion to avoid repeated mapper
+  requests and mapping decodes. [#489](https://github.com/pulumi/pulumi-converter-terraform/pull/489)
 
 - Convert the Terraform `can` builtin to the PCL `can` intrinsic, now that the
   PCL code generator supports it.

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,8 +3,9 @@
 - Cache HCL syntax tokens per source file to reduce converter CPU use and
   allocations.
   [#490](https://github.com/pulumi/pulumi-converter-terraform/pull/490)
-- Cache provider mappings during bulk example conversion to avoid repeated mapper
-  requests and mapping decodes. [#489](https://github.com/pulumi/pulumi-converter-terraform/pull/489)
+- Cache provider mappings during Terraform program and state conversion to avoid
+  repeated mapper requests and mapping decodes.
+  [#489](https://github.com/pulumi/pulumi-converter-terraform/pull/489)
 
 - Convert the Terraform `can` builtin to the PCL `can` intrinsic, now that the
   PCL code generator supports it.

--- a/cmd/pulumi-converter-terraform/main.go
+++ b/cmd/pulumi-converter-terraform/main.go
@@ -99,7 +99,7 @@ func (*tfConverter) ConvertProgram(_ context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("create mapper: %w", err)
 	}
-	var providerInfoSource tfconvert.ProviderInfoSource = tfconvert.NewMapperProviderInfoSource(mapper)
+	providerInfoSource := tfconvert.NewMapperProviderInfoSource(mapper)
 	providerInfoResolver := tfconvert.NewProviderInfoResolver()
 
 	if req.LoaderTarget == "" {
@@ -111,6 +111,8 @@ func (*tfConverter) ConvertProgram(_ context.Context,
 	}
 
 	if *convertExamples != "" {
+		// Examples in one bulk request repeatedly use the same provider mappings. Keep the cache
+		// request-scoped so separate conversions cannot reuse mappings for different plugin state.
 		providerInfoSource = tfconvert.NewCachingProviderInfoSource(providerInfoSource)
 
 		//nolint:gosec // path is user-provided input from the CLI

--- a/cmd/pulumi-converter-terraform/main.go
+++ b/cmd/pulumi-converter-terraform/main.go
@@ -50,7 +50,9 @@ func (*tfConverter) ConvertState(_ context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("create mapper: %w", err)
 	}
-	providerInfoSource := tfconvert.NewMapperProviderInfoSource(mapper)
+	providerInfoSource := tfconvert.NewCachingProviderInfoSource(
+		tfconvert.NewMapperProviderInfoSource(mapper),
+	)
 
 	if len(req.Args) != 1 {
 		return nil, errors.New("expected exactly one argument")
@@ -99,7 +101,9 @@ func (*tfConverter) ConvertProgram(_ context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("create mapper: %w", err)
 	}
-	providerInfoSource := tfconvert.NewMapperProviderInfoSource(mapper)
+	providerInfoSource := tfconvert.NewCachingProviderInfoSource(
+		tfconvert.NewMapperProviderInfoSource(mapper),
+	)
 	providerInfoResolver := tfconvert.NewProviderInfoResolver()
 
 	if req.LoaderTarget == "" {
@@ -111,10 +115,6 @@ func (*tfConverter) ConvertProgram(_ context.Context,
 	}
 
 	if *convertExamples != "" {
-		// Examples in one bulk request repeatedly use the same provider mappings. Keep the cache
-		// request-scoped so separate conversions cannot reuse mappings for different plugin state.
-		providerInfoSource = tfconvert.NewCachingProviderInfoSource(providerInfoSource)
-
 		//nolint:gosec // path is user-provided input from the CLI
 		examplesBytes, err := os.ReadFile(filepath.Join(req.SourceDirectory, *convertExamples))
 		if err != nil {

--- a/cmd/pulumi-converter-terraform/main.go
+++ b/cmd/pulumi-converter-terraform/main.go
@@ -99,7 +99,7 @@ func (*tfConverter) ConvertProgram(_ context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("create mapper: %w", err)
 	}
-	providerInfoSource := tfconvert.NewMapperProviderInfoSource(mapper)
+	var providerInfoSource tfconvert.ProviderInfoSource = tfconvert.NewMapperProviderInfoSource(mapper)
 	providerInfoResolver := tfconvert.NewProviderInfoResolver()
 
 	if req.LoaderTarget == "" {
@@ -111,6 +111,8 @@ func (*tfConverter) ConvertProgram(_ context.Context,
 	}
 
 	if *convertExamples != "" {
+		providerInfoSource = tfconvert.NewCachingProviderInfoSource(providerInfoSource)
+
 		//nolint:gosec // path is user-provided input from the CLI
 		examplesBytes, err := os.ReadFile(filepath.Join(req.SourceDirectory, *convertExamples))
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/zclconf/go-cty v1.17.0
 	golang.org/x/crypto v0.55.0
+	golang.org/x/sync v0.22.0
 	google.golang.org/grpc v1.83.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -276,7 +277,6 @@ require (
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.41.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/pulumi/pulumi/pkg/v3 v3.257.0
 	github.com/pulumi/pulumi/sdk/v3 v3.257.0
 	github.com/pulumi/terraform v0.13.0
+	github.com/segmentio/encoding v0.5.4
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
@@ -224,7 +225,6 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
-	github.com/segmentio/encoding v0.3.6 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4008,8 +4008,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
-github.com/segmentio/encoding v0.3.6 h1:E6lVLyDPseWEulBmCmAKPanDd3jiyGDo5gMcugCRwZQ=
-github.com/segmentio/encoding v0.3.6/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
@@ -4841,7 +4841,6 @@ golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211110154304-99a53858aa08/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211210111614-af8b64212486/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/convert/info.go
+++ b/pkg/convert/info.go
@@ -127,8 +127,12 @@ func (s *mapperProviderInfoSource) GetProviderInfo(
 	// Keep mapping immutable after parsing: zero-copy strings retain its backing bytes for as
 	// long as the resulting ProviderInfo needs them.
 	remainder, err := json.Parse(mapping, &info, json.ZeroCopy)
-	if err != nil || len(remainder) != 0 {
-		return nil, fmt.Errorf("could not decode mapping information for provider %s: %s", tfProvider, mapping)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode mapping information for provider %s: %w", tfProvider, err)
+	}
+	if len(remainder) != 0 {
+		return nil, fmt.Errorf("could not decode mapping information for provider %s: "+
+			"unexpected trailing data %q", tfProvider, remainder)
 	}
 
 	return info.Unmarshal(), nil

--- a/pkg/convert/info.go
+++ b/pkg/convert/info.go
@@ -123,6 +123,8 @@ func (s *mapperProviderInfoSource) GetProviderInfo(
 	}
 
 	var info tfbridge.MarshallableProviderInfo
+	// Keep mapping immutable after parsing: zero-copy strings retain its backing bytes for as
+	// long as the resulting ProviderInfo needs them.
 	if _, err := json.Parse(mapping, &info, json.ZeroCopy); err != nil {
 		return nil, fmt.Errorf("could not decode mapping information for provider %s: %s", tfProvider, mapping)
 	}

--- a/pkg/convert/info.go
+++ b/pkg/convert/info.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/terraform/pkg/configs"
 	"github.com/pulumi/terraform/pkg/getproviders"
 	"github.com/segmentio/encoding/json"
+	"golang.org/x/sync/singleflight"
 )
 
 // ProviderInfoSource is an interface for retrieving information about a bridged Terraform provider.
@@ -125,7 +126,8 @@ func (s *mapperProviderInfoSource) GetProviderInfo(
 	var info tfbridge.MarshallableProviderInfo
 	// Keep mapping immutable after parsing: zero-copy strings retain its backing bytes for as
 	// long as the resulting ProviderInfo needs them.
-	if _, err := json.Parse(mapping, &info, json.ZeroCopy); err != nil {
+	remainder, err := json.Parse(mapping, &info, json.ZeroCopy)
+	if err != nil || len(remainder) != 0 {
 		return nil, fmt.Errorf("could not decode mapping information for provider %s: %s", tfProvider, mapping)
 	}
 
@@ -134,7 +136,8 @@ func (s *mapperProviderInfoSource) GetProviderInfo(
 
 // CachingProviderInfoSource wraps a ProviderInfoSource in a cache for faster access.
 type CachingProviderInfoSource struct {
-	lock sync.RWMutex
+	lock     sync.RWMutex
+	requests singleflight.Group
 
 	source  ProviderInfoSource
 	entries map[string]*tfbridge.ProviderInfo
@@ -159,20 +162,27 @@ func (s *CachingProviderInfoSource) GetProviderInfo(
 		return info, nil
 	}
 
-	s.lock.Lock()
-	defer s.lock.Unlock()
-	// Another goroutine may have populated the entry while this caller waited.
-	if info, ok := s.entries[key]; ok {
-		return info, nil
-	}
+	value, err, _ := s.requests.Do(key, func() (any, error) {
+		// Another request may have populated the cache before this call started.
+		if info, ok := s.getFromCache(key); ok {
+			return info, nil
+		}
 
-	info, err := s.source.GetProviderInfo(provider, requiredProvider)
+		info, err := s.source.GetProviderInfo(provider, requiredProvider)
+		if err != nil {
+			// Do not retain transient mapper, registry, or plugin failures.
+			return nil, err
+		}
+
+		s.lock.Lock()
+		s.entries[key] = info
+		s.lock.Unlock()
+		return info, nil
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	s.entries[key] = info
-	return info, nil
+	return value.(*tfbridge.ProviderInfo), nil
 }
 
 func providerInfoCacheKey(provider string, requiredProvider *configs.RequiredProvider) string {

--- a/pkg/convert/info.go
+++ b/pkg/convert/info.go
@@ -16,7 +16,6 @@ package convert
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -30,6 +29,7 @@ import (
 	"github.com/pulumi/terraform/pkg/addrs"
 	"github.com/pulumi/terraform/pkg/configs"
 	"github.com/pulumi/terraform/pkg/getproviders"
+	"github.com/segmentio/encoding/json"
 )
 
 // ProviderInfoSource is an interface for retrieving information about a bridged Terraform provider.
@@ -122,9 +122,8 @@ func (s *mapperProviderInfoSource) GetProviderInfo(
 		return nil, errors.New(mappingMessage)
 	}
 
-	var info *tfbridge.MarshallableProviderInfo
-	err = json.Unmarshal(mapping, &info)
-	if err != nil {
+	var info tfbridge.MarshallableProviderInfo
+	if _, err := json.Parse(mapping, &info, json.ZeroCopy); err != nil {
 		return nil, fmt.Errorf("could not decode mapping information for provider %s: %s", tfProvider, mapping)
 	}
 
@@ -153,20 +152,36 @@ func (s *CachingProviderInfoSource) GetProviderInfo(
 	provider string,
 	requiredProvider *configs.RequiredProvider,
 ) (*tfbridge.ProviderInfo, error) {
-	if info, ok := s.getFromCache(provider); ok {
+	key := providerInfoCacheKey(provider, requiredProvider)
+	if info, ok := s.getFromCache(key); ok {
 		return info, nil
 	}
 
 	s.lock.Lock()
 	defer s.lock.Unlock()
+	// Another goroutine may have populated the entry while this caller waited.
+	if info, ok := s.entries[key]; ok {
+		return info, nil
+	}
 
 	info, err := s.source.GetProviderInfo(provider, requiredProvider)
 	if err != nil {
 		return nil, err
 	}
 
-	s.entries[provider] = info
+	s.entries[key] = info
 	return info, nil
+}
+
+func providerInfoCacheKey(provider string, requiredProvider *configs.RequiredProvider) string {
+	pulumiProvider := provider
+	if renamed, ok := pulumiRenamedProviderNames[provider]; ok {
+		pulumiProvider = renamed
+	}
+	if !isTerraformProvider(pulumiProvider) || requiredProvider == nil {
+		return provider
+	}
+	return provider + "\x00" + requiredProvider.Source + "\x00" + requiredProvider.Requirement.Required.String()
 }
 
 // getFromCache retrieves the provider information from the cache, taking a read lock to do so.

--- a/pkg/convert/info_cache_test.go
+++ b/pkg/convert/info_cache_test.go
@@ -15,8 +15,10 @@
 package convert
 
 import (
+	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	version "github.com/hashicorp/go-version"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
@@ -67,6 +69,84 @@ func TestCachingProviderInfoSourceDeduplicatesConcurrentRequests(t *testing.T) {
 		require.NoError(t, errs[i])
 		require.Same(t, want, results[i])
 	}
+}
+
+func TestCachingProviderInfoSourceDoesNotBlockUnrelatedCachedKeys(t *testing.T) {
+	t.Parallel()
+
+	cachedInfo := &tfbridge.ProviderInfo{}
+	slowInfo := &tfbridge.ProviderInfo{}
+	slowStarted := make(chan struct{})
+	releaseSlow := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseSlow) }) }
+	t.Cleanup(release)
+
+	source := providerInfoSourceFunc(func(
+		provider string, _ *configs.RequiredProvider,
+	) (*tfbridge.ProviderInfo, error) {
+		switch provider {
+		case "cached":
+			return cachedInfo, nil
+		case "slow":
+			close(slowStarted)
+			<-releaseSlow
+			return slowInfo, nil
+		default:
+			return nil, errors.New("unexpected provider")
+		}
+	})
+	cache := NewCachingProviderInfoSource(source)
+
+	got, err := cache.GetProviderInfo("cached", nil)
+	require.NoError(t, err)
+	require.Same(t, cachedInfo, got)
+
+	slowDone := make(chan error, 1)
+	go func() {
+		_, err := cache.GetProviderInfo("slow", nil)
+		slowDone <- err
+	}()
+	<-slowStarted
+
+	cachedDone := make(chan error, 1)
+	go func() {
+		got, err := cache.GetProviderInfo("cached", nil)
+		if err == nil && got != cachedInfo {
+			err = errors.New("cached provider info changed")
+		}
+		cachedDone <- err
+	}()
+
+	select {
+	case err := <-cachedDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("cached lookup blocked behind an unrelated source request")
+	}
+
+	release()
+	require.NoError(t, <-slowDone)
+}
+
+func TestCachingProviderInfoSourceDoesNotCacheErrors(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("transient mapper failure")
+	calls := 0
+	source := providerInfoSourceFunc(func(
+		_ string, _ *configs.RequiredProvider,
+	) (*tfbridge.ProviderInfo, error) {
+		calls++
+		return nil, wantErr
+	})
+	cache := NewCachingProviderInfoSource(source)
+
+	_, err := cache.GetProviderInfo("aws", nil)
+	require.ErrorIs(t, err, wantErr)
+	_, err = cache.GetProviderInfo("aws", nil)
+	require.ErrorIs(t, err, wantErr)
+	require.Equal(t, 2, calls)
 }
 
 func TestCachingProviderInfoSourceSeparatesDynamicProviderIdentities(t *testing.T) {

--- a/pkg/convert/info_cache_test.go
+++ b/pkg/convert/info_cache_test.go
@@ -1,0 +1,129 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"sync"
+	"testing"
+
+	version "github.com/hashicorp/go-version"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/terraform/pkg/configs"
+	"github.com/stretchr/testify/require"
+)
+
+type providerInfoSourceFunc func(string, *configs.RequiredProvider) (*tfbridge.ProviderInfo, error)
+
+func (f providerInfoSourceFunc) GetProviderInfo(
+	provider string,
+	requiredProvider *configs.RequiredProvider,
+) (*tfbridge.ProviderInfo, error) {
+	return f(provider, requiredProvider)
+}
+
+func TestCachingProviderInfoSourceDeduplicatesConcurrentRequests(t *testing.T) {
+	t.Parallel()
+
+	const callers = 32
+	want := &tfbridge.ProviderInfo{}
+	var calls int
+	source := providerInfoSourceFunc(func(
+		_ string, _ *configs.RequiredProvider,
+	) (*tfbridge.ProviderInfo, error) {
+		calls++
+		return want, nil
+	})
+	cache := NewCachingProviderInfoSource(source)
+
+	start := make(chan struct{})
+	results := make([]*tfbridge.ProviderInfo, callers)
+	errs := make([]error, callers)
+	var workers sync.WaitGroup
+	workers.Add(callers)
+	for i := range callers {
+		go func() {
+			defer workers.Done()
+			<-start
+			results[i], errs[i] = cache.GetProviderInfo("aws", nil)
+		}()
+	}
+	close(start)
+	workers.Wait()
+
+	require.Equal(t, 1, calls)
+	for i := range callers {
+		require.NoError(t, errs[i])
+		require.Same(t, want, results[i])
+	}
+}
+
+func TestCachingProviderInfoSourceSeparatesDynamicProviderIdentities(t *testing.T) {
+	t.Parallel()
+
+	constraint1, err := version.NewConstraint("~> 1.0")
+	require.NoError(t, err)
+	constraint2, err := version.NewConstraint("~> 2.0")
+	require.NoError(t, err)
+
+	required1 := &configs.RequiredProvider{
+		Source: "registry.example.com/example/provider",
+		Requirement: configs.VersionConstraint{
+			Required: constraint1,
+		},
+	}
+	required2 := &configs.RequiredProvider{
+		Source: "registry.example.com/example/provider",
+		Requirement: configs.VersionConstraint{
+			Required: constraint2,
+		},
+	}
+	required3 := &configs.RequiredProvider{
+		Source: "registry.example.com/other/provider",
+		Requirement: configs.VersionConstraint{
+			Required: constraint1,
+		},
+	}
+	want1 := &tfbridge.ProviderInfo{}
+	want2 := &tfbridge.ProviderInfo{}
+	want3 := &tfbridge.ProviderInfo{}
+	infos := map[string]*tfbridge.ProviderInfo{
+		providerInfoCacheKey("example", required1): want1,
+		providerInfoCacheKey("example", required2): want2,
+		providerInfoCacheKey("example", required3): want3,
+	}
+	calls := 0
+	source := providerInfoSourceFunc(func(
+		provider string, required *configs.RequiredProvider,
+	) (*tfbridge.ProviderInfo, error) {
+		calls++
+		return infos[providerInfoCacheKey(provider, required)], nil
+	})
+	cache := NewCachingProviderInfoSource(source)
+
+	got1, err := cache.GetProviderInfo("example", required1)
+	require.NoError(t, err)
+	got1Again, err := cache.GetProviderInfo("example", required1)
+	require.NoError(t, err)
+	got2, err := cache.GetProviderInfo("example", required2)
+	require.NoError(t, err)
+	got3, err := cache.GetProviderInfo("example", required3)
+	require.NoError(t, err)
+
+	require.Same(t, want1, got1)
+	require.Same(t, want1, got1Again)
+	require.Same(t, want2, got2)
+	require.Same(t, want3, got3)
+	require.Equal(t, 3, calls)
+}

--- a/pkg/convert/info_test.go
+++ b/pkg/convert/info_test.go
@@ -20,6 +20,7 @@ import (
 
 	bridgetesting "github.com/pulumi/pulumi-converter-terraform/pkg/testing"
 	codegenconvert "github.com/pulumi/pulumi/pkg/v3/codegen/convert"
+	segmentjson "github.com/segmentio/encoding/json"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,7 +39,28 @@ func TestMapperProviderInfoSourceRejectsTrailingMappingData(t *testing.T) {
 	}
 
 	_, err := NewMapperProviderInfoSource(mapper).GetProviderInfo("aws", nil)
+	require.EqualError(t, err,
+		`could not decode mapping information for provider aws: unexpected trailing data "trailing data"`)
+}
+
+func TestMapperProviderInfoSourceReportsMappingSyntaxErrors(t *testing.T) {
+	t.Parallel()
+
+	mapper := &bridgetesting.MockMapper{
+		GetMappingF: func(
+			context.Context,
+			string,
+			*codegenconvert.MapperPackageHint,
+			string,
+		) ([]byte, error) {
+			return []byte("{"), nil
+		},
+	}
+
+	_, err := NewMapperProviderInfoSource(mapper).GetProviderInfo("aws", nil)
 	require.ErrorContains(t, err, "could not decode mapping information for provider aws")
+	var syntaxError *segmentjson.SyntaxError
+	require.ErrorAs(t, err, &syntaxError)
 }
 
 func TestMapperProviderInfoSourceAllowsTrailingMappingWhitespace(t *testing.T) {

--- a/pkg/convert/info_test.go
+++ b/pkg/convert/info_test.go
@@ -1,0 +1,60 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"context"
+	"testing"
+
+	bridgetesting "github.com/pulumi/pulumi-converter-terraform/pkg/testing"
+	codegenconvert "github.com/pulumi/pulumi/pkg/v3/codegen/convert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapperProviderInfoSourceRejectsTrailingMappingData(t *testing.T) {
+	t.Parallel()
+
+	mapper := &bridgetesting.MockMapper{
+		GetMappingF: func(
+			context.Context,
+			string,
+			*codegenconvert.MapperPackageHint,
+			string,
+		) ([]byte, error) {
+			return []byte("{} trailing data"), nil
+		},
+	}
+
+	_, err := NewMapperProviderInfoSource(mapper).GetProviderInfo("aws", nil)
+	require.ErrorContains(t, err, "could not decode mapping information for provider aws")
+}
+
+func TestMapperProviderInfoSourceAllowsTrailingMappingWhitespace(t *testing.T) {
+	t.Parallel()
+
+	mapper := &bridgetesting.MockMapper{
+		GetMappingF: func(
+			context.Context,
+			string,
+			*codegenconvert.MapperPackageHint,
+			string,
+		) ([]byte, error) {
+			return []byte("{} \n\t"), nil
+		},
+	}
+
+	_, err := NewMapperProviderInfoSource(mapper).GetProviderInfo("aws", nil)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Program and state conversion can retrieve and decode the same provider mapping more than once. In the bulk AWS benchmark corpus, this caused 6,679 mapper calls and repeated decoding of the same 11 MB mapping.

This change adds a request-scoped provider information cache for program and state conversion. Pulumi-managed providers, such as AWS, are cached by provider name. Dynamically bridged Terraform providers are cached by name, registry source, and version constraint because each combination can produce a different mapping.

Concurrent requests for the same key share one source call through `singleflight`, while different provider keys load independently. Successful results enter the request cache. Mapper, registry, and plugin errors remain transient and are not retained.

Provider mappings are decoded with Segmentio's zero-copy parser. The mapping bytes remain immutable and are retained for the lifetime of the resulting `ProviderInfo`. This avoids copying decoded strings, but it retains the mapping buffer while the cache is in use. Segmentio is declared as a direct dependency at v0.5.4. The decoder also preserves the previous behavior of rejecting data after the top-level JSON value.

Each `ConvertProgram` or `ConvertState` RPC creates a new cache, so mappings are not shared across requests or plugin state.

## Benchmark

These results were measured with a separate AWS bulk conversion benchmark harness that will be proposed separately. The harness:

- converts 3,736 captured Terraform examples from the AWS provider
- uses a captured 11 MB AWS provider mapping
- compares every generated PCL result, `Pulumi.yaml` file, and diagnostic with the captured expected output
- records mapper calls, allocations, garbage collections, and peak RSS

The benchmark found no conversion output changes after this optimization.

| Metric | Baseline | After this change |
|---|---:|---:|
| Median conversion time | 164,056.569 ms | 687.870 ms |
| Allocated bytes | 849.7 GB | 4.45 GB |
| Mallocs | 9.65 billion | 8.65 million |
| GC cycles | 1,170 | 33 |
| Mapper calls | 6,679 | 28 |
| Peak RSS | 2.93 GB | 397 MB |

The latest three candidate samples were 837.784, 639.120, and 687.870 ms. Wall-time variation was 14.35%, but the mapper-call, allocation, and GC reductions were consistent.

Focused tests cover concurrent request deduplication, independent provider keys, transient source errors, trailing mapping data, and separation of dynamic provider source and version identities.

Validation:

- `go test ./pkg/convert ./cmd/pulumi-converter-terraform`
- `go test -race ./pkg/convert -run 'Test(CachingProviderInfoSource|MapperProviderInfoSource)' -count=1`
- `golangci-lint run -c ./.golangci.yml --timeout 10m`
- `go mod verify`
- `git diff --check`
- AWS bulk corpus benchmark, three repetitions

