### PR TITLE
Cache HCL tokens for trivia extraction

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,9 @@
 ### Improvements
 
+- Cache HCL syntax tokens per source file to reduce converter CPU use and
+  allocations.
+  [#490](https://github.com/pulumi/pulumi-converter-terraform/pull/490)
+
 - Convert the Terraform `can` builtin to the PCL `can` intrinsic, now that the
   PCL code generator supports it.
   [#295](https://github.com/pulumi/pulumi-converter-terraform/pull/295)

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -269,16 +269,31 @@ func getTrivaFromIndex(tokens hclsyntax.Tokens, first, last int, blockLike bool)
 // significant and return ["# leading trivia", "/* trailing trivia a */"] for local_a, and ["# leading trivia
 // b\n/* more leading trivia */", "# trailing trivia"] for local_b.
 
-func getTrivia(sources map[string][]byte, r hcl.Range, blockLike bool) (hclwrite.Tokens, hclwrite.Tokens) {
-	// Load the file referenced in the range
-	src, has := sources[r.Filename]
-	if !has {
-		// This shouldn't ever be hit, "sources" is a list of every file we parsed earlier and ranges should
-		// only come from those.
-		panic(fmt.Sprintf("Could not read '%s' to parse trivia", r.Filename))
+type sourceCache struct {
+	sources map[string][]byte
+	tokens  map[string]hclsyntax.Tokens
+}
+
+func newSourceCache(sources map[string][]byte) *sourceCache {
+	return &sourceCache{sources: sources, tokens: make(map[string]hclsyntax.Tokens, len(sources))}
+}
+
+func (s *sourceCache) tokensFor(filename string) hclsyntax.Tokens {
+	if tokens, ok := s.tokens[filename]; ok {
+		return tokens
 	}
-	tokens, _ := hclsyntax.LexConfig(src, r.Filename, hcl.Pos{Byte: 0, Line: 1, Column: 1})
-	// Ignore the diagnostics, we already know this is parsable because we've got the hcl.Range for it
+	src, ok := s.sources[filename]
+	if !ok {
+		panic(fmt.Sprintf("Could not read '%s' to parse trivia", filename))
+	}
+	tokens, _ := hclsyntax.LexConfig(src, filename, hcl.Pos{Byte: 0, Line: 1, Column: 1})
+	// Ignore diagnostics: loadConfigDir already established that this source is parsable.
+	s.tokens[filename] = tokens
+	return tokens
+}
+
+func getTrivia(sources *sourceCache, r hcl.Range, blockLike bool) (hclwrite.Tokens, hclwrite.Tokens) {
+	tokens := sources.tokensFor(r.Filename)
 
 	// Find the index of the first and last token matching the input
 	var first, last int
@@ -295,16 +310,8 @@ func getTrivia(sources map[string][]byte, r hcl.Range, blockLike bool) (hclwrite
 }
 
 // Given a HCL range for an attribute expression find the full range for that attribute
-func getAttributeRange(sources map[string][]byte, r hcl.Range) hcl.Range {
-	// Load the file referenced in the range
-	src, has := sources[r.Filename]
-	if !has {
-		// This shouldn't ever be hit, "sources" is a list of every file we parsed earlier and ranges should
-		// only come from those.
-		panic(fmt.Sprintf("Could not read '%s' to parse trivia", r.Filename))
-	}
-	tokens, _ := hclsyntax.LexConfig(src, r.Filename, hcl.Pos{Byte: 0, Line: 1, Column: 1})
-	// Ignore the diagnostics, we already know this is parsable because we've got the hcl.Range for it
+func getAttributeRange(sources *sourceCache, r hcl.Range) hcl.Range {
+	tokens := sources.tokensFor(r.Filename)
 
 	// Find the index of the first token matching the input range
 	var first int
@@ -332,16 +339,8 @@ func getAttributeRange(sources map[string][]byte, r hcl.Range) hcl.Range {
 }
 
 // Given a HCL range return the tokens for that range
-func getTokensForRange(sources map[string][]byte, r hcl.Range) hclwrite.Tokens {
-	// Load the file referenced in the range
-	src, has := sources[r.Filename]
-	if !has {
-		// This shouldn't ever be hit, "sources" is a list of every file we parsed earlier and ranges should
-		// only come from those.
-		panic(fmt.Sprintf("Could not read '%s' to parse trivia", r.Filename))
-	}
-	tokens, _ := hclsyntax.LexConfig(src, r.Filename, hcl.Pos{Byte: 0, Line: 1, Column: 1})
-	// Ignore the diagnostics, we already know this is parsable because we've got the hcl.Range for it
+func getTokensForRange(sources *sourceCache, r hcl.Range) hclwrite.Tokens {
+	tokens := sources.tokensFor(r.Filename)
 
 	// Find the tokens for this range
 	rangeTokens := make(hclwrite.Tokens, 0)
@@ -882,8 +881,8 @@ var tfFunctionStd = map[string]struct {
 }
 
 type convertState struct {
-	// The sources for the HCL files we're converting
-	sources map[string][]byte
+	// The sources and lazily lexed tokens for the HCL files we're converting.
+	sources *sourceCache
 
 	// Diagnostic messages from conversion
 	diagnostics hcl.Diagnostics
@@ -1417,7 +1416,7 @@ func convertTemplateExpr(state *convertState,
 func detectHeredocDelim(state *convertState, r hcl.Range) (string, string, bool) {
 	hereDocRegex := regexp.MustCompile(`^<<-?([[:alpha:]]+)\n`)
 
-	file := state.sources[r.Filename]
+	file := state.sources.sources[r.Filename]
 	start := r.Start.Byte
 	hereDocStr := hereDocRegex.FindSubmatch(file[start:])
 	if hereDocStr != nil {
@@ -4176,7 +4175,7 @@ func translateModuleSourceCode(
 	scopes.loader = loader
 
 	state := &convertState{
-		sources:              sources,
+		sources:              newSourceCache(sources),
 		diagnostics:          hcl.Diagnostics{},
 		rewriteObjectKeys:    true,
 		sandboxedModuleNames: make(map[string]string),
@@ -4349,7 +4348,7 @@ func translateModuleSourceCode(
 	}
 	for _, item := range items {
 		if item.moduleCall != nil {
-			leadingTrivia, _ := getTrivia(sources, item.moduleCall.DeclRange, false)
+			leadingTrivia, _ := getTrivia(state.sources, item.moduleCall.DeclRange, false)
 			packageName, wrapUsingTerraformModule := findPulumiTerraformModuleAnnotation(string(leadingTrivia.Bytes()))
 			moduleCall := item.moduleCall
 			moduleName := scopes.getOrAddPulumiName("module."+moduleCall.Name, "", "Component")

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -269,6 +269,8 @@ func getTrivaFromIndex(tokens hclsyntax.Tokens, first, last int, blockLike bool)
 // significant and return ["# leading trivia", "/* trailing trivia a */"] for local_a, and ["# leading trivia
 // b\n/* more leading trivia */", "# trailing trivia"] for local_b.
 
+// sourceCache belongs to one convertState. Translation within that state is serial, so lazy
+// token population needs no synchronization.
 type sourceCache struct {
 	sources map[string][]byte
 	tokens  map[string]hclsyntax.Tokens

--- a/pkg/convert/tf.go
+++ b/pkg/convert/tf.go
@@ -272,19 +272,19 @@ func getTrivaFromIndex(tokens hclsyntax.Tokens, first, last int, blockLike bool)
 // sourceCache belongs to one convertState. Translation within that state is serial, so lazy
 // token population needs no synchronization.
 type sourceCache struct {
-	sources map[string][]byte
-	tokens  map[string]hclsyntax.Tokens
+	sourceBytes map[string][]byte
+	tokens      map[string]hclsyntax.Tokens
 }
 
 func newSourceCache(sources map[string][]byte) *sourceCache {
-	return &sourceCache{sources: sources, tokens: make(map[string]hclsyntax.Tokens, len(sources))}
+	return &sourceCache{sourceBytes: sources, tokens: make(map[string]hclsyntax.Tokens, len(sources))}
 }
 
 func (s *sourceCache) tokensFor(filename string) hclsyntax.Tokens {
 	if tokens, ok := s.tokens[filename]; ok {
 		return tokens
 	}
-	src, ok := s.sources[filename]
+	src, ok := s.sourceBytes[filename]
 	if !ok {
 		panic(fmt.Sprintf("Could not read '%s' to parse trivia", filename))
 	}
@@ -1418,7 +1418,7 @@ func convertTemplateExpr(state *convertState,
 func detectHeredocDelim(state *convertState, r hcl.Range) (string, string, bool) {
 	hereDocRegex := regexp.MustCompile(`^<<-?([[:alpha:]]+)\n`)
 
-	file := state.sources.sources[r.Filename]
+	file := state.sources.sourceBytes[r.Filename]
 	start := r.Start.Byte
 	hereDocStr := hereDocRegex.FindSubmatch(file[start:])
 	if hereDocStr != nil {


### PR DESCRIPTION
## Why

Trivia and range lookups currently call `hclsyntax.LexConfig` for the complete source file. Files with many expressions are therefore tokenized many times, which repeats scanner work and creates short-lived allocations.

## What changed

This PR lazily tokenizes each source file once per `convertState` and reuses the token slice for later lookups. Source bytes are immutable and translation within one state is serial, so the cache does not need invalidation or synchronization.

Range lookup still scans the cached tokens. This change only removes repeated tokenization; it does not change trivia or range behavior.

## Performance

Captured AWS workload: 3,736 Terraform examples.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Bulk conversion | 697.667 ms | 399.534 ms | -42.7% |
| Allocated bytes | 4.45 GB | 1.63 GB | -63.3% |
| User CPU | 5.70 s | 1.89 s | -66.8% |
| GC cycles | 33 | 14 | -57.6% |

All converted outputs and the canonical normalized output hash were unchanged. Wall time had higher variance, but the allocation and GC reductions reproduced closely. These are incremental measurements on the experimental optimization stack, not a direct comparison with `main`.

## Validation

- `go test ./pkg/convert`
